### PR TITLE
Fix an error during the compilation of slls

### DIFF
--- a/src/slls/slls.F90
+++ b/src/slls/slls.F90
@@ -66,14 +66,10 @@
 
      INTERFACE SLLS_initialize
        MODULE PROCEDURE SLLS_initialize, SLLS_full_initialize
-            
-     USE GALAHAD_KINDS
      END INTERFACE SLLS_initialize
 
      INTERFACE SLLS_terminate
        MODULE PROCEDURE SLLS_terminate, SLLS_full_terminate
-            
-     USE GALAHAD_KINDS
      END INTERFACE SLLS_terminate
 
 !--------------------


### PR DESCRIPTION
It solved the following error:
```shell
FAILED: libgalahad_single.so.p/src_slls_slls.F90.o libgalahad_single.so.p/galahad_slls_precision.mod 
gfortran -Ilibgalahad_single.so.p -I. -I.. -I../include -Ilibgalahad_metis.so.p -Ilibpastix_single.so.p -Ilibwsmp.so.p -Ilibspmf.so.p -Ilibmumps_single.so.p -Ilibspral_ssids_single.so.p -Ilibmkl_pardiso.so.p -Ilibpardiso.so.p -Ilibgalahad_hsl_double.so.p -Ilibgalahad_hsl_single.so.p -Ilibgalahad_lapack.so.p -Ilibgalahad_blas.so.p -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -g -fPIC -DGALAHAD_SINGLE -Jlibgalahad_single.so.p -o libgalahad_single.so.p/src_slls_slls.F90.o -c ../src/slls/slls.F90
../src/slls/slls.F90:70:22:

   70 |      USE GALAHAD_KINDS
      |                      1
Error: Unexpected USE statement in INTERFACE block at (1)
../src/slls/slls.F90:76:22:

   76 |      USE GALAHAD_KINDS
      |                      1
Error: Unexpected USE statement in INTERFACE block at (1)
../src/slls/slls.F90:4461:48:
```