### PR TITLE
Update standalone.yml

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -68,16 +68,19 @@ jobs:
             cxx_cmd: g++
           - os: windows-latest
             compiler: intel
+            version:
             cc_cmd: icl
             fc_cmd: ifort
             cxx_cmd: icl
           - os: ubuntu-latest
             compiler: intel
+            version:
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc
           - os: macos-latest
             compiler: intel
+            version:
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -7,12 +7,12 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    name: GALAHAD/${{ matrix.os }}/${{ matrix.compiler }}/${{ matrix.version }}
+    name: GALAHAD/${{ matrix.os }}/${{ matrix.compiler }}/${{ matrix.compiler_version }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        version: [10, 11, 12]
+        compiler_version: [10, 11, 12]
         include:
           - compiler: gnu
             cc_cmd: gcc
@@ -20,19 +20,19 @@ jobs:
             cxx_cmd: g++
           - os: windows-latest
             compiler: intel
-            version: latest
+            compiler_version: latest
             cc_cmd: icl
             fc_cmd: ifort
             cxx_cmd: icl
           - os: ubuntu-latest
             compiler: intel
-            version: latest
+            compiler_version: latest
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc
           - os: macos-latest
             compiler: intel
-            version: latest
+            compiler_version: latest
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc
@@ -59,7 +59,7 @@ jobs:
         uses: awvwgk/setup-fortran@main
         with:
           compiler: gcc
-          version: ${{ matrix.version }}
+          version: ${{ matrix.compiler_version }}
 
       - name: Install Intel OpenAPI C and Fortran compilers
         if: matrix.compiler == 'intel'

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    name: GALAHAD/${{ matrix.os }}/${{ matrix.compiler }}/${{ matrix.compiler }}/${{ matrix.version }}
+    name: GALAHAD/${{ matrix.os }}/${{ matrix.compiler }}/${{ matrix.version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    name: GALAHAD/${{ matrix.os }}/${{ matrix.compiler }}
+    name: GALAHAD/${{ matrix.os }}/${{ matrix.compiler }}/${{ matrix.compiler }}/${{ matrix.version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -20,19 +20,19 @@ jobs:
             cxx_cmd: g++
           - os: windows-latest
             compiler: intel
-            version:
+            version: latest
             cc_cmd: icl
             fc_cmd: ifort
             cxx_cmd: icl
           - os: ubuntu-latest
             compiler: intel
-            version:
+            version: latest
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc
           - os: macos-latest
             compiler: intel
-            version:
+            version: latest
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -14,38 +14,70 @@ jobs:
         include:
           - os: windows-latest
             compiler: gnu
+            version: 10
+            cc_cmd: gcc
+            fc_cmd: gfortran
+            cxx_cmd: g++
+          - os: windows-latest
+            compiler: gnu
+            version: 11
+            cc_cmd: gcc
+            fc_cmd: gfortran
+            cxx_cmd: g++
+          - os: windows-latest
+            compiler: gnu
+            version: 12
             cc_cmd: gcc
             fc_cmd: gfortran
             cxx_cmd: g++
           - os: ubuntu-latest
             compiler: gnu
+            version: 10
+            cc_cmd: gcc
+            fc_cmd: gfortran
+            cxx_cmd: g++
+          - os: ubuntu-latest
+            compiler: gnu
+            version: 11
+            cc_cmd: gcc
+            fc_cmd: gfortran
+            cxx_cmd: g++
+          - os: ubuntu-latest
+            compiler: gnu
+            version: 12
             cc_cmd: gcc
             fc_cmd: gfortran
             cxx_cmd: g++
           - os: macos-latest
             compiler: gnu
+            version: 10
+            cc_cmd: gcc
+            fc_cmd: gfortran
+            cxx_cmd: g++
+          - os: macos-latest
+            compiler: gnu
+            version: 11
+            cc_cmd: gcc
+            fc_cmd: gfortran
+            cxx_cmd: g++
+          - os: macos-latest
+            compiler: gnu
+            version: 12
             cc_cmd: gcc
             fc_cmd: gfortran
             cxx_cmd: g++
           - os: windows-latest
             compiler: intel
-            hpckit: https://registrationcenter-download.intel.com/akdlm/irc_nas/19085/w_HPCKit_p_2023.0.0.25931_offline.ex
-            # hpckit: 'https://registrationcenter-download.intel.com/akdlm/irc_nas/xxx/w_HPCKit_p_2022.3.1.19755_offline.exe'
-            script: 'install_windows.bat'
-            cc_cmd: icc
+            cc_cmd: icl
             fc_cmd: ifort
-            cxx_cmd: icpc
+            cxx_cmd: icl
           - os: ubuntu-latest
             compiler: intel
-            hpckit: 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18975/l_HPCKit_p_2022.3.1.16997_offline.sh'
-            script: 'install_linux.sh'
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc
           - os: macos-latest
             compiler: intel
-            hpckit: 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18977/m_HPCKit_p_2022.3.1.15344_offline.dmg'
-            script: 'install_macos.sh'
             cc_cmd: icc
             fc_cmd: ifort
             cxx_cmd: icpc
@@ -60,16 +92,18 @@ jobs:
       - name: Install Meson and Ninja
         run: pip install meson ninja
       - name: Install GNU C and Fortran compilers
-        uses: modflowpy/install-gfortran-action@v1
+        if: matrix.compiler == 'gnu'
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: gcc
+          version: ${{ matrix.version }}
       - name: Install Intel OpenAPI C and Fortran compilers
         if: matrix.compiler == 'intel'
-        run: |
-          .github/scripts/${{ matrix.script }} "${{ matrix.hpckit }}" all
+        uses: modflowpy/install-intelfortran-action@v1
       - name: Setup GALAHAD build
         shell: bash
         run: |
-          [[ "${{ matrix.compiler }}" == "intel" ]] && source /opt/intel/oneapi/setvars.sh
-          meson setup builddir -Dciface=true
+          meson setup builddir
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}
@@ -77,7 +111,6 @@ jobs:
       - name: Build GALAHAD
         shell: bash
         run: |
-          [[ "${{ matrix.compiler }}" == "intel" ]] && source /opt/intel/oneapi/setvars.sh
           meson compile -C builddir
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -87,7 +120,6 @@ jobs:
       - name: Test GALAHAD
         shell: bash
         run: |
-          [[ "${{ matrix.compiler }}" == "intel" ]] && source /opt/intel/oneapi/setvars.sh
           meson test -C builddir
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -11,58 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        version: [10, 11, 12]
         include:
-          - os: windows-latest
-            compiler: gnu
-            version: 10
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: windows-latest
-            compiler: gnu
-            version: 11
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: windows-latest
-            compiler: gnu
-            version: 12
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: ubuntu-latest
-            compiler: gnu
-            version: 10
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: ubuntu-latest
-            compiler: gnu
-            version: 11
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: ubuntu-latest
-            compiler: gnu
-            version: 12
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: macos-latest
-            compiler: gnu
-            version: 10
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: macos-latest
-            compiler: gnu
-            version: 11
-            cc_cmd: gcc
-            fc_cmd: gfortran
-            cxx_cmd: g++
-          - os: macos-latest
-            compiler: gnu
-            version: 12
+          - compiler: gnu
             cc_cmd: gcc
             fc_cmd: gfortran
             cxx_cmd: g++
@@ -88,22 +40,32 @@ jobs:
     steps:
       - name: Check out GALAHAD
         uses: actions/checkout@v3
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+
       - name: Install Meson and Ninja
         run: pip install meson ninja
+
+      - name: Set environment variables
+        shell: bash
+        run: |
+          echo "GALAHAD=/home/runner/work/GALAHAD/GALAHAD" >> $GITHUB_ENV
+
       - name: Install GNU C and Fortran compilers
         if: matrix.compiler == 'gnu'
         uses: awvwgk/setup-fortran@main
         with:
           compiler: gcc
           version: ${{ matrix.version }}
+
       - name: Install Intel OpenAPI C and Fortran compilers
         if: matrix.compiler == 'intel'
         uses: modflowpy/install-intelfortran-action@v1
-      - name: Setup GALAHAD build
+
+      - name: Setup GALAHAD
         shell: bash
         run: |
           meson setup builddir
@@ -111,6 +73,7 @@ jobs:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}
           CXX: ${{ matrix.cxx_cmd }}
+
       - name: Build GALAHAD
         shell: bash
         run: |
@@ -120,6 +83,7 @@ jobs:
         with:
           name: ${{ matrix.os }}_meson_log
           path: builddir/meson-logs/testlog.txt
+
       - name: Test GALAHAD
         shell: bash
         run: |


### PR DESCRIPTION
@jfowkes @nimgould 
I updated the workflow such that we test three version of GCC (10 / 11 / 12) for each platform (Windows/Linux/Mac).
I also changed how the Intel compilers are installed to fix some installation issues on Windows.

For information, `icl` is the C/X++ compiler on Windows and it replaces `icc/icpc`.