### PR TITLE
[Meson] Add Python interface

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,7 @@ task:
       brew install meson gcc
     fi
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
+    pip install numpy
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
       FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dpythoniface=true -Dlibblas= -Dliblapack=

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,12 +9,13 @@ task:
   dependencies_script: |
     echo $(uname)
     if [ "$(uname)" = "FreeBSD" ]; then
-      pkg install -y python meson bash gcc12
+      pkg install -y py39-pip meson bash gcc12
+      pip install numpy
     else
       brew install python meson gcc
+      pip3 install numpy
     fi
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
-    pip3 install numpy
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
       FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dpythoniface=true -Dlibblas= -Dliblapack=

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,9 +16,9 @@ task:
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
-      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dlibblas= -Dliblapack=
+      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dpythoniface=true -Dlibblas= -Dliblapack=
     else
-      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad -Dlibblas= -Dliblapack=
+      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad -Dpythoniface=true -Dlibblas= -Dliblapack=
     fi
   build_script: |
     meson compile -C builddir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
       brew install python meson gcc
     fi
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
-    pip install numpy
+    pip3 install numpy
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
       FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dpythoniface=true -Dlibblas= -Dliblapack=

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,9 +9,9 @@ task:
   dependencies_script: |
     echo $(uname)
     if [ "$(uname)" = "FreeBSD" ]; then
-      pkg install -y meson bash gcc12
+      pkg install -y python meson bash gcc12
     else
-      brew install meson gcc
+      brew install python meson gcc
     fi
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
     pip install numpy

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Meson and Ninja
-        run: pip install meson ninja
+        run: pip install meson ninja numpy
 
       - name: Set environment variables
         shell: bash

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build GALAHAD
         shell: bash
         run: |
-          meson compile -C builddir
+          meson compile -C builddir -Dpythoniface=true
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dlibblas= -Dliblapack=
+          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true -Dlibblas= -Dliblapack=
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}
@@ -82,7 +82,7 @@ jobs:
       - name: Build GALAHAD
         shell: bash
         run: |
-          meson compile -C builddir -Dpythoniface=true
+          meson compile -C builddir
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/meson.build
+++ b/meson.build
@@ -440,41 +440,23 @@ if build_tests and build_ciface
 endif
 
 # Python tests
-if build_tests and build_pythoniface and build_ciface and build_double
+if false
+  if build_tests and build_pythoniface and build_ciface and build_double
 
-  python_tests_folder = 'tests/Python'
+    python_tests_folder = 'tests/Python'
 
-  foreach test: galahad_python_tests
-    package = test[0]
-    name = test[1]
-    file = test[2]
-    test(name,
-         executable(name, file, link_with : libgalahad_python, link_language : 'c', include_directories : libgalahad_include,
-                                install : true, install_dir : python_tests_folder),
-         suite : [package, 'Python'],
-         is_parallel : false)
-  endforeach
+    foreach test: galahad_python_tests
+      package = test[0]
+      name = test[1]
+      file = test[2]
+      test(name,
+           executable(name, file, link_with : libgalahad_python, link_language : 'c', include_directories : libgalahad_include,
+                                  install : true, install_dir : python_tests_folder),
+           suite : [package, 'Python'],
+           is_parallel : false)
+    endforeach
+  endif
 endif
-
-#   arc_py = executable('arc_py', 'src/arc/Python/test_arc.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('arc_py', arc_py, suite: ['arc', 'Python'], is_parallel : false)
-#   bgo_py = executable('bgo_py', 'src/bgo/Python/test_bgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('bgo_py', bgo_py, suite: ['bgo', 'Python'], is_parallel : false)
-#   bgo_quadratic_py = executable('bgo_quadratic_py', 'src/bgo/Python/test_bgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('bgo_quadratic_py', bgo_quadratic_py, suite: ['bgo', 'Python'], is_parallel : false)
-#   dgo_py = executable('dgo_py', 'src/dgo/Python/test_dgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('dgo_py', dgo_py, suite: ['dgo', 'Python'], is_parallel : false)
-#   dgo_quadratic_py = executable('dgo_quadratic_py', 'src/dgo/Python/test_dgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('dgo_quadratic_py', dgo_quadratic_py, suite: ['dgo', 'Python'], is_parallel : false)
-#   nls_py = executable('nls_py', 'src/nls/Python/test_nls.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('nls_py', nls_py, suite: ['nls', 'Python'], is_parallel : false)
-#   trb_py = executable('trb_py', 'src/trb/Python/test_trb.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('trb_py', trb_py, suite: ['trb', 'Python'], is_parallel : false)
-#   tru_py = executable('tru_py', 'src/tru/Python/test_tru.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('tru_py', tru_py, suite: ['tru', 'Python'], is_parallel : false)
-#   ugo_py = executable('ugo_py', 'src/ugo/Python/test_ugo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('ugo_py', ugo_py, suite: ['ugo', 'Python'], is_parallel : false)
-# endif
 
 # Fortran examples
 if build_examples and build_double

--- a/meson.build
+++ b/meson.build
@@ -351,7 +351,6 @@ if build_pythoniface and build_ciface and build_double
 
     libgalahad_python = py.extension_module(name,
                                             sources : file,
-                                            link_args: ['-Wl,-Bsymbolic', '-Wl,-Bsymbolic-functions'],
                                             link_with : libgalahad_double,
                                             link_language : 'c',
                                             include_directories : libgalahad_include,

--- a/meson.build
+++ b/meson.build
@@ -148,6 +148,7 @@ libgalahad_c_src = []
 libgalahad_cpp_src = []
 libgalahad_cutest_src = []
 libgalahad_ampl_src = []
+libgalahad_python_src = []
 
 galahad_examples = []
 galahad_c_examples = []
@@ -456,3 +457,36 @@ if build_examples and build_ciface
     endforeach
   endforeach
 endif
+
+if build_pythoniface
+  libgalahad_python = library('galahad_python',
+                              sources : libgalahad_python_src,
+                              link_with : libgalahad_c_double,
+                              link_language : 'c',
+                              include_directories: libgalahad_include,
+                              install : true)
+endif
+
+# if build_tests and build_pythoniface
+
+#   python_tests_folder = 'share/tests/Python'
+
+#   arc_py = executable('arc_py', 'src/arc/Python/test_arc.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('arc_py', arc_py, suite: ['arc', 'Python'], is_parallel : false)
+#   bgo_py = executable('bgo_py', 'src/bgo/Python/test_bgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('bgo_py', bgo_py, suite: ['bgo', 'Python'], is_parallel : false)
+#   bgo_quadratic_py = executable('bgo_quadratic_py', 'src/bgo/Python/test_bgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('bgo_quadratic_py', bgo_quadratic_py, suite: ['bgo', 'Python'], is_parallel : false)
+#   dgo_py = executable('dgo_py', 'src/dgo/Python/test_dgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('dgo_py', dgo_py, suite: ['dgo', 'Python'], is_parallel : false)
+#   dgo_quadratic_py = executable('dgo_quadratic_py', 'src/dgo/Python/test_dgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('dgo_quadratic_py', dgo_quadratic_py, suite: ['dgo', 'Python'], is_parallel : false)
+#   nls_py = executable('nls_py', 'src/nls/Python/test_nls.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('nls_py', nls_py, suite: ['nls', 'Python'], is_parallel : false)
+#   trb_py = executable('trb_py', 'src/trb/Python/test_trb.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('trb_py', trb_py, suite: ['trb', 'Python'], is_parallel : false)
+#   tru_py = executable('tru_py', 'src/tru/Python/test_tru.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('tru_py', tru_py, suite: ['tru', 'Python'], is_parallel : false)
+#   ugo_py = executable('ugo_py', 'src/ugo/Python/test_ugo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('ugo_py', ugo_py, suite: ['ugo', 'Python'], is_parallel : false)
+# endif

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,10 @@ elif fc.get_id() == 'nagfor'
   pp_options += ['-fpp', '-F']
 endif
 
+if cxx.get_id() == 'gcc' or cxx.get_id() == 'intel' or cxx.get_id() == 'intel-cl'
+  add_global_arguments('-MD', language : 'cpp')
+endif
+
 # Options
 install_modules = get_option('modules')
 

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c', 'cpp', 'fortran',
   version: '5.0.0',
   license: 'BSD-3',
-  meson_version: '>= 0.61.0',
+  meson_version: '>= 0.63.0',
   default_options: [
     'buildtype=debug',
     'libdir=lib',
@@ -355,9 +355,9 @@ if build_pythoniface and build_ciface and build_double
 
     libgalahad_python = py.extension_module(name,
                                             sources : file,
+                                            link_args: '-Wl,-Bsymbolic-functions',
                                             link_with : libgalahad_double,
                                             link_language : 'c',
-                                            dependencies : py.dependency(),
                                             include_directories : libgalahad_include,
                                             subdir : 'galahad',
                                             install : true)

--- a/meson.build
+++ b/meson.build
@@ -345,14 +345,19 @@ if build_pythoniface and build_ciface and build_double
   ).stdout().strip()
   libgalahad_include += [incdir_numpy]
   
-  libgalahad_python = py.extension_module('libgalahad_python',
-                                          sources : libgalahad_python_src,
-                                          link_with : libgalahad_double,
-                                          link_language : 'c',
-                                          dependencies : py.dependency(),
-                                          include_directories : libgalahad_include,
-                                          subdir : 'galahad',
-                                          install : true)
+  foreach interface: libgalahad_python_src
+    name = interface[0]
+    file = interface[1]
+
+    libgalahad_python = py.extension_module(name,
+                                            sources : file,
+                                            link_with : libgalahad_double,
+                                            link_language : 'c',
+                                            dependencies : py.dependency(),
+                                            include_directories : libgalahad_include,
+                                            subdir : 'galahad',
+                                            install : true)
+  endforeach
 endif
 
 # Binaries

--- a/meson.build
+++ b/meson.build
@@ -46,10 +46,6 @@ elif fc.get_id() == 'nagfor'
   pp_options += ['-fpp', '-F']
 endif
 
-if cxx.get_id() == 'gcc' or cxx.get_id() == 'intel' or cxx.get_id() == 'intel-cl'
-  add_global_arguments('-MD', language : 'cpp')
-endif
-
 # Options
 install_modules = get_option('modules')
 

--- a/meson.build
+++ b/meson.build
@@ -448,6 +448,8 @@ endif
 
 # Python tests
 if false
+  # TO DO: Add a check to insure that the shared library for the Python interfaces
+  # is installed in a relevant location.
   if build_tests and build_pythoniface and build_ciface and build_double
 
     python_tests_folder = 'tests/Python'
@@ -457,8 +459,8 @@ if false
       name = test[1]
       file = test[2]
       test(name,
-           executable(name, file, link_with : libgalahad_python, link_language : 'c', include_directories : libgalahad_include,
-                                  install : true, install_dir : python_tests_folder),
+           py,
+           args : file,
            suite : [package, 'Python'],
            is_parallel : false)
     endforeach

--- a/meson.build
+++ b/meson.build
@@ -349,8 +349,9 @@ if build_pythoniface and build_ciface and build_double
                                           sources : libgalahad_python_src,
                                           link_with : libgalahad_double,
                                           link_language : 'c',
-                                          dependencies: py.dependency(),
-                                          include_directories: libgalahad_include,
+                                          dependencies : py.dependency(),
+                                          include_directories : libgalahad_include,
+                                          subdir : 'galahad',
                                           install : true)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,6 @@ project(
   ],
 )
 
-
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 fc = meson.get_compiler('fortran')
@@ -156,6 +155,7 @@ galahad_examples = []
 galahad_c_examples = []
 galahad_tests = []
 galahad_c_tests = []
+galahad_python_tests = []
 
 # Headers and Fortran modules
 libgalahad_include = [include_directories('include'),
@@ -338,6 +338,16 @@ if build_double
                               install : true)
 endif
 
+if build_pythoniface and build_ciface and build_double
+  libgalahad_python = py.extension_module('libgalahad_python',
+                                          sources : libgalahad_python_src,
+                                          link_with : libgalahad_double,
+                                          link_language : 'c',
+                                          dependencies: py.dependency(),
+                                          include_directories: libgalahad_include,
+                                          install : true)
+endif
+
 # Binaries
 foreach binary: galahad_binaries
   binname = binary[0]
@@ -429,6 +439,43 @@ if build_tests and build_ciface
   endforeach
 endif
 
+# Python tests
+if build_tests and build_pythoniface and build_ciface and build_double
+
+  python_tests_folder = 'tests/Python'
+
+  foreach test: galahad_python_tests
+    package = test[0]
+    name = test[1]
+    file = test[2]
+    test(name,
+         executable(name, file, link_with : libgalahad_python, link_language : 'c', include_directories : libgalahad_include,
+                                install : true, install_dir : python_tests_folder),
+         suite : [package, 'Python'],
+         is_parallel : false)
+  endforeach
+endif
+
+#   arc_py = executable('arc_py', 'src/arc/Python/test_arc.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('arc_py', arc_py, suite: ['arc', 'Python'], is_parallel : false)
+#   bgo_py = executable('bgo_py', 'src/bgo/Python/test_bgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('bgo_py', bgo_py, suite: ['bgo', 'Python'], is_parallel : false)
+#   bgo_quadratic_py = executable('bgo_quadratic_py', 'src/bgo/Python/test_bgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('bgo_quadratic_py', bgo_quadratic_py, suite: ['bgo', 'Python'], is_parallel : false)
+#   dgo_py = executable('dgo_py', 'src/dgo/Python/test_dgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('dgo_py', dgo_py, suite: ['dgo', 'Python'], is_parallel : false)
+#   dgo_quadratic_py = executable('dgo_quadratic_py', 'src/dgo/Python/test_dgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('dgo_quadratic_py', dgo_quadratic_py, suite: ['dgo', 'Python'], is_parallel : false)
+#   nls_py = executable('nls_py', 'src/nls/Python/test_nls.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('nls_py', nls_py, suite: ['nls', 'Python'], is_parallel : false)
+#   trb_py = executable('trb_py', 'src/trb/Python/test_trb.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('trb_py', trb_py, suite: ['trb', 'Python'], is_parallel : false)
+#   tru_py = executable('tru_py', 'src/tru/Python/test_tru.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('tru_py', tru_py, suite: ['tru', 'Python'], is_parallel : false)
+#   ugo_py = executable('ugo_py', 'src/ugo/Python/test_ugo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
+#   test('ugo_py', ugo_py, suite: ['ugo', 'Python'], is_parallel : false)
+# endif
+
 # Fortran examples
 if build_examples and build_double
 
@@ -459,37 +506,3 @@ if build_examples and build_ciface
     endforeach
   endforeach
 endif
-
-if build_pythoniface
-  libgalahad_python = py.extension_module('galahad_python',
-                                          sources : libgalahad_python_src,
-                                          link_with : libgalahad_c_double,
-                                          link_language : 'c',
-                                          dependencies: py.dependency(),
-                                          include_directories: libgalahad_include,
-                                          install : true)
-endif
-
-# if build_tests and build_pythoniface
-
-#   python_tests_folder = 'share/tests/Python'
-
-#   arc_py = executable('arc_py', 'src/arc/Python/test_arc.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('arc_py', arc_py, suite: ['arc', 'Python'], is_parallel : false)
-#   bgo_py = executable('bgo_py', 'src/bgo/Python/test_bgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('bgo_py', bgo_py, suite: ['bgo', 'Python'], is_parallel : false)
-#   bgo_quadratic_py = executable('bgo_quadratic_py', 'src/bgo/Python/test_bgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('bgo_quadratic_py', bgo_quadratic_py, suite: ['bgo', 'Python'], is_parallel : false)
-#   dgo_py = executable('dgo_py', 'src/dgo/Python/test_dgo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('dgo_py', dgo_py, suite: ['dgo', 'Python'], is_parallel : false)
-#   dgo_quadratic_py = executable('dgo_quadratic_py', 'src/dgo/Python/test_dgo_quadratic.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('dgo_quadratic_py', dgo_quadratic_py, suite: ['dgo', 'Python'], is_parallel : false)
-#   nls_py = executable('nls_py', 'src/nls/Python/test_nls.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('nls_py', nls_py, suite: ['nls', 'Python'], is_parallel : false)
-#   trb_py = executable('trb_py', 'src/trb/Python/test_trb.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('trb_py', trb_py, suite: ['trb', 'Python'], is_parallel : false)
-#   tru_py = executable('tru_py', 'src/tru/Python/test_tru.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('tru_py', tru_py, suite: ['tru', 'Python'], is_parallel : false)
-#   ugo_py = executable('ugo_py', 'src/ugo/Python/test_ugo.py', link_with : libgalahad_python, link_language: 'cython', include_directories: libgalahad_include)
-#   test('ugo_py', ugo_py, suite: ['ugo', 'Python'], is_parallel : false)
-# endif

--- a/meson.build
+++ b/meson.build
@@ -14,11 +14,13 @@ project(
   ],
 )
 
+
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 fc = meson.get_compiler('fortran')
 fc_compiler = find_program(fc.cmd_array())
 fs = import('fs')
+py = import('python').find_installation()
 
 # Remove messages about deprecated Intel compilers
 if cc.get_id() == 'intel' or cc.get_id() == 'intel-cl'
@@ -459,12 +461,13 @@ if build_examples and build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python = library('galahad_python',
-                              sources : libgalahad_python_src,
-                              link_with : libgalahad_c_double,
-                              link_language : 'c',
-                              include_directories: libgalahad_include,
-                              install : true)
+  libgalahad_python = py.extension_module('galahad_python',
+                                          sources : libgalahad_python_src,
+                                          link_with : libgalahad_c_double,
+                                          link_language : 'c',
+                                          dependencies: py.dependency(),
+                                          include_directories: libgalahad_include,
+                                          install : true)
 endif
 
 # if build_tests and build_pythoniface

--- a/meson.build
+++ b/meson.build
@@ -344,19 +344,33 @@ if build_pythoniface and build_ciface and build_double
     check : true
   ).stdout().strip()
   libgalahad_include += [incdir_numpy]
-  
-  foreach interface: libgalahad_python_src
-    name = interface[0]
-    file = interface[1]
 
-    libgalahad_python = py.extension_module(name,
-                                            sources : file,
-                                            link_with : libgalahad_double,
-                                            link_language : 'c',
-                                            include_directories : libgalahad_include,
-                                            subdir : 'galahad',
-                                            install : true)
+  py_src = []
+  foreach interface: libgalahad_python_src
+    file = interface[1]
+    py_src += file
   endforeach
+
+  py.extension_module('galahad',
+                      sources : py_src,
+                      link_with : libgalahad_double,
+                      link_language : 'c',
+                      include_directories : libgalahad_include,
+                      subdir : 'galahad',
+                      install : true)
+
+  # foreach interface: libgalahad_python_src
+  #   name = interface[0]
+  #   file = interface[1]
+
+  #   py.extension_module(name,
+  #                       sources : file,
+  #                       link_with : libgalahad_double,
+  #                       link_language : 'c',
+  #                       include_directories : libgalahad_include,
+  #                       subdir : 'galahad',
+  #                       install : true)
+  # endforeach
 endif
 
 # Binaries
@@ -460,25 +474,23 @@ if build_tests and build_ciface
 endif
 
 # Python tests
-if false
-  # TO DO: Add a check to insure that the shared library for the Python interfaces
-  # is installed in a relevant location.
-  if build_tests and build_pythoniface and build_ciface and build_double
+# if build_tests and build_pythoniface and build_ciface and build_double
 
-    python_tests_folder = 'tests/Python'
+#   pypathdir = meson.current_build_dir()
+#   python_tests_folder = 'tests/Python'
 
-    foreach test: galahad_python_tests
-      package = test[0]
-      name = test[1]
-      file = test[2]
-      test(name,
-           py,
-           args : file,
-           suite : [package, 'Python'],
-           is_parallel : false)
-    endforeach
-  endif
-endif
+#   foreach test: galahad_python_tests
+#     package = test[0]
+#     name = test[1]
+#     file = test[2]
+#     test(name,
+#          py,
+#          args : file,
+#          suite : [package, 'Python'],
+#          env : ['PYTHONPATH=' + pypathdir],
+#          is_parallel : false)
+#   endforeach
+# endif
 
 # Fortran examples
 if build_examples and build_double

--- a/meson.build
+++ b/meson.build
@@ -355,7 +355,7 @@ if build_pythoniface and build_ciface and build_double
 
     libgalahad_python = py.extension_module(name,
                                             sources : file,
-                                            link_args: '-Wl,-Bsymbolic-functions',
+                                            link_args: ['-Wl,-Bsymbolic', '-Wl,-Bsymbolic-functions'],
                                             link_with : libgalahad_double,
                                             link_language : 'c',
                                             include_directories : libgalahad_include,

--- a/meson.build
+++ b/meson.build
@@ -339,6 +339,12 @@ if build_double
 endif
 
 if build_pythoniface and build_ciface and build_double
+  incdir_numpy = run_command(py,
+    ['-c', 'import numpy; print(numpy.get_include())'],
+    check : true
+  ).stdout().strip()
+  libgalahad_include += [incdir_numpy]
+  
   libgalahad_python = py.extension_module('libgalahad_python',
                                           sources : libgalahad_python_src,
                                           link_with : libgalahad_double,

--- a/meson.build
+++ b/meson.build
@@ -417,9 +417,18 @@ if build_tests
       package = test[0]
       name = test[1] + '_' + precision
       file = test[2]
+
+      deps_tests = libgalahad_deps
+      if precision == 'single'
+        deps_tests += libgalahad_single_deps
+      endif
+      if precision == 'double'
+        deps_tests += libgalahad_double_deps
+      endif
+
       if not (name == 'croti_single')
         test(name,
-             executable(name, file, fortran_args : args_precision, link_with : libgalahad_precision, dependencies : libgalahad_deps,
+             executable(name, file, fortran_args : args_precision, link_with : libgalahad_precision, dependencies : deps_tests,
                                     link_language : 'fortran', include_directories: libgalahad_include , install : true,
                                     install_dir : fortran_tests_folder),
              suite : [package, precision, 'fortran'],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,7 +10,7 @@ option('ciface',
 
 option('pythoniface',
        type : 'boolean',
-       value : true,
+       value : false,
        description : 'whether to build the Python interface in double precision')
 
 option('examples',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,7 +10,7 @@ option('ciface',
 
 option('pythoniface',
        type : 'boolean',
-       value : false,
+       value : true,
        description : 'whether to build the Python interface in double precision')
 
 option('examples',

--- a/src/arc/meson.build
+++ b/src/arc/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/arc_pyiface.c')
+  libgalahad_python_src += [['arc', files('Python/arc_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/arc/meson.build
+++ b/src/arc/meson.build
@@ -18,6 +18,8 @@ galahad_tests += [['arc', 'arct', files('arct.F90')],
 galahad_c_tests += [['arc', 'arct_c', files('C/arct.c')],
                     ['arc', 'arctf_c', files('C/arctf.c')]]
 
+galahad_python_tests += [['arc', 'arc_py', files('Python/test_arc.py')]]
+
 galahad_examples += [['arcs', files('arcs.f90')],
                      ['arcs2', files('arcs2.f90')],
                      ['arcs3', files('arcs3.f90')],

--- a/src/arc/meson.build
+++ b/src/arc/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('arc.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/arc_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/arc_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usearc.F90', 'runarc_sif.F90')
 endif

--- a/src/bgo/meson.build
+++ b/src/bgo/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/bgo_pyiface.c')
+  libgalahad_python_src += [['bgo', files('Python/bgo_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/bgo/meson.build
+++ b/src/bgo/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('bgo.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/bgo_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/bgo_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usebgo.F90', 'runbgo_sif.F90')
 endif

--- a/src/bgo/meson.build
+++ b/src/bgo/meson.build
@@ -18,6 +18,9 @@ galahad_tests += [['bgo', 'bgot', files('bgot.F90')],
 galahad_c_tests += [['bgo', 'bgot_c', files('C/bgot.c')],
                     ['bgo', 'bgotf_c', files('C/bgotf.c')]]
 
+galahad_python_tests += [['bgo', 'bgo_py', files('Python/test_bgo.py')],
+                         ['bgo', 'bgo_quadratic_py', files('Python/test_bgo_quadratic.py')]]
+
 galahad_examples += [['bgos', files('bgos.f90')],
                      ['bgos2', files('bgos2.f90')]]
 

--- a/src/blls/meson.build
+++ b/src/blls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('blls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/blls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['blls', files('Python/blls_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useblls.F90', 'runblls_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['blls', 'bllst', files('bllst.F90')],
 
 galahad_c_tests += [['blls', 'bllst_c', files('C/bllst.c')],
                     ['blls', 'bllstf_c', files('C/bllstf.c')]]
+
+galahad_python_tests += [['blls', 'blls_py', files('Python/test_blls.py')]]
 
 galahad_examples += [['bllss', files('bllss.f90')],
                      ['bllss2', files('bllss2.f90')],

--- a/src/bqp/meson.build
+++ b/src/bqp/meson.build
@@ -6,12 +6,12 @@ if build_ciface
   libgalahad_c_src += files('C/bqp_ciface.F90')
 endif
 
-if libcutest.found()
-  libgalahad_cutest_src += files('usebqp.F90', 'runbqp_sif.F90')
+if build_pythoniface
+  libgalahad_python_src += [['bqp', files('Python/bqp_pyiface.c')]]
 endif
 
-if build_pythoniface
-  libgalahad_python_src += files('Python/bqp_pyiface.c')
+if libcutest.found()
+  libgalahad_cutest_src += files('usebqp.F90', 'runbqp_sif.F90')
 endif
 
 galahad_tests += [['bqp', 'bqpt', files('bqpt.F90')],

--- a/src/bqp/meson.build
+++ b/src/bqp/meson.build
@@ -1,10 +1,17 @@
 libgalahad_src += files('bqp.F90')
+
 galahad_binaries += [['inbqp', files('inbqp.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/bqp_ciface.F90')
 endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usebqp.F90', 'runbqp_sif.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/bqp_pyiface.c')
 endif
 
 galahad_tests += [['bqp', 'bqpt', files('bqpt.F90')],
@@ -12,6 +19,8 @@ galahad_tests += [['bqp', 'bqpt', files('bqpt.F90')],
 
 galahad_c_tests += [['bqp', 'bqpt_c', files('C/bqpt.c')],
                     ['bqp', 'bqptf_c', files('C/bqptf.c')]]
+
+galahad_python_tests += [['bqp', 'bqp_py', files('Python/test_bqp.py')]]
 
 galahad_examples += [['bqps', files('bqps.f90')],
                      ['bqps2', files('bqps2.f90')],

--- a/src/bqpb/meson.build
+++ b/src/bqpb/meson.build
@@ -1,10 +1,17 @@
 libgalahad_src += files('bqpb.F90')
+
 galahad_binaries += [['inbqpb', files('inbqpb.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/bqpb_ciface.F90')
 endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usebqpb.F90', 'runbqpb_sif.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/bqpb_pyiface.c')
 endif
 
 galahad_tests += [['bqpb', 'bqpbt', files('bqpbt.F90')],
@@ -12,6 +19,8 @@ galahad_tests += [['bqpb', 'bqpbt', files('bqpbt.F90')],
 
 galahad_c_tests += [['bqpb', 'bqpbt_c', files('C/bqpbt.c')],
                     ['bqpb', 'bqpbtf_c', files('C/bqpbtf.c')]]
+
+galahad_python_tests += [['bqpb', 'bqpb_py', files('Python/test_bqpb.py')]]
 
 galahad_examples += [['bqpbs', files('bqpbs.f90')],
                      ['bqpbs2', files('bqpbs2.f90')]]

--- a/src/bqpb/meson.build
+++ b/src/bqpb/meson.build
@@ -6,12 +6,12 @@ if build_ciface
   libgalahad_c_src += files('C/bqpb_ciface.F90')
 endif
 
-if libcutest.found()
-  libgalahad_cutest_src += files('usebqpb.F90', 'runbqpb_sif.F90')
+if build_pythoniface
+  libgalahad_python_src += [['bqpb', files('Python/bqpb_pyiface.c')]]
 endif
 
-if build_pythoniface
-  libgalahad_python_src += files('Python/bqpb_pyiface.c')
+if libcutest.found()
+  libgalahad_cutest_src += files('usebqpb.F90', 'runbqpb_sif.F90')
 endif
 
 galahad_tests += [['bqpb', 'bqpbt', files('bqpbt.F90')],

--- a/src/bsc/meson.build
+++ b/src/bsc/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('bsc.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/bsc_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['bsc', files('Python/bsc_pyiface.c')]]
+endif
+
 galahad_tests += [['bsc', 'bsct', files('bsct.F90')]]
+
+galahad_python_tests += [['bsc', 'bsc_py', files('Python/test_bsc.py')]]
 
 galahad_examples += [['bscs', files('bscs.f90')]]

--- a/src/convert/meson.build
+++ b/src/convert/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('convert.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/convert_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['convert', files('Python/convert_pyiface.c')]]
+endif
+
 galahad_tests += [['convert', 'convertt', files('convertt.F90')]]
+
+galahad_python_tests += [['convert', 'convert_py', files('Python/test_convert.py')]]
 
 galahad_examples += [['converts', files('converts.f90')]]

--- a/src/cqp/meson.build
+++ b/src/cqp/meson.build
@@ -7,7 +7,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/cqp_pyiface.c')
+  libgalahad_python_src += [['cqp', files('Python/cqp_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/cqp/meson.build
+++ b/src/cqp/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('cqp.F90')
+
 galahad_binaries += [['incqp', files('incqp.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/cqp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/cqp_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usecqp.F90', 'runcqp_sif.F90')
 endif

--- a/src/cqp/meson.build
+++ b/src/cqp/meson.build
@@ -20,6 +20,8 @@ galahad_tests += [['cqp', 'cqpt', files('cqpt.F90')],
 galahad_c_tests += [['cqp', 'cqpt_c', files('C/cqpt.c')],
                     ['cqp', 'cqptf_c', files('C/cqptf.c')]]
 
+galahad_python_tests += [['cqp', 'cqp_py', files('Python/test_cqp.py')]]
+
 galahad_examples += [['cqps', files('cqps.f90')],
                      ['cqps2', files('cqps2.f90')],
                      ['cqps3', files('cqps3.f90')]]

--- a/src/cro/meson.build
+++ b/src/cro/meson.build
@@ -4,11 +4,17 @@ if build_ciface
   libgalahad_c_src += files('C/cro_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['cro', files('Python/cro_pyiface.c')]]
+endif
+
 galahad_tests += [['cro', 'crot', files('crot.F90')],
                   ['cro', 'croti', files('croti.F90')]]
 
 galahad_c_tests += [['cro', 'crot_c', files('C/crot.c')],
                     ['cro', 'crotf_c', files('C/crotf.c')]]
+
+galahad_python_tests += [['cro', 'cro_py', files('Python/test_cro.py')]]
 
 galahad_examples += [['cros', files('cros.f90')],
                      ['cros2', files('cros2.f90')],

--- a/src/dgo/meson.build
+++ b/src/dgo/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/dgo_pyiface.c')
+  libgalahad_python_src += [['dgo', files('Python/dgo_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/dgo/meson.build
+++ b/src/dgo/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('dgo.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/dgo_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/dgo_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usedgo.F90', 'rundgo_sif.F90')
 endif

--- a/src/dgo/meson.build
+++ b/src/dgo/meson.build
@@ -18,6 +18,9 @@ galahad_tests += [['dgo', 'dgot', files('dgot.F90')],
 galahad_c_tests += [['dgo', 'dgot_c', files('C/dgot.c')],
                     ['dgo', 'dgotf_c', files('C/dgotf.c')]]
 
+galahad_python_tests += [['dgo', 'dgo_py', files('Python/test_dgo.py')],
+                         ['dgo', 'dgo_quadratic_py', files('Python/test_dgo_quadratic.py')]]
+
 galahad_examples += [['dgos', files('dgos.f90')],
                      ['dgos2', files('dgos2.f90')]]
 

--- a/src/dps/meson.build
+++ b/src/dps/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('dps.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/dps_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/dps_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usedps.F90', 'rundps_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['dps', 'dpst', files('dpst.F90')]]
 
 galahad_c_tests += [['dps', 'dpst_c', files('C/dpst.c')],
                     ['dps', 'dpstf_c', files('C/dpstf.c')]]
+
+galahad_python_tests += [['dps', 'dps_py', files('Python/test_dps.py')]]
 
 galahad_examples += [['dpss', files('dpss.f90')],
                      ['dpss2', files('dpss2.f90')]]

--- a/src/dps/meson.build
+++ b/src/dps/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/dps_pyiface.c')
+  libgalahad_python_src += [['dps', files('Python/dps_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/dqp/meson.build
+++ b/src/dqp/meson.build
@@ -21,6 +21,8 @@ galahad_c_tests += [['dqp', 'dqpt_c', files('C/dqpt.c')],
                     ['dqp', 'dqpt2_c', files('C/dqpt2.c')],
                     ['dqp', 'dqptf_c', files('C/dqptf.c')]]
 
+galahad_python_tests += [['dqp', 'dqp_py', files('Python/test_dqp.py')]]
+
 galahad_examples += [['dqps', files('dqps.f90')],
                      ['dqps2', files('dqps2.f90')],
                      ['dqps3', files('dqps3.f90')]]

--- a/src/dqp/meson.build
+++ b/src/dqp/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('dqp.F90')
+
 galahad_binaries += [['indqp', files('indqp.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/dqp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/dqp_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usedqp.F90', 'rundqp_sif.F90')
 endif

--- a/src/dqp/meson.build
+++ b/src/dqp/meson.build
@@ -7,7 +7,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/dqp_pyiface.c')
+  libgalahad_python_src += [['dqp', files('Python/dqp_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/eqp/meson.build
+++ b/src/eqp/meson.build
@@ -4,12 +4,12 @@ if build_ciface
   libgalahad_c_src += files('C/eqp_ciface.F90')
 endif
 
-if libcutest.found()
-  libgalahad_cutest_src += files('useeqp.F90', 'runeqp_sif.F90')
+if build_pythoniface
+  libgalahad_python_src += [['eqp', files('Python/eqp_pyiface.c')]]
 endif
 
-if build_pythoniface
-  libgalahad_python_src += files('Python/eqp_pyiface.c')
+if libcutest.found()
+  libgalahad_cutest_src += files('useeqp.F90', 'runeqp_sif.F90')
 endif
 
 galahad_tests += [['eqp', 'eqpt', files('eqpt.F90')],

--- a/src/eqp/meson.build
+++ b/src/eqp/meson.build
@@ -1,9 +1,15 @@
 libgalahad_src += files('eqp.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/eqp_ciface.F90')
 endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useeqp.F90', 'runeqp_sif.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/eqp_pyiface.c')
 endif
 
 galahad_tests += [['eqp', 'eqpt', files('eqpt.F90')],
@@ -11,5 +17,7 @@ galahad_tests += [['eqp', 'eqpt', files('eqpt.F90')],
 
 galahad_c_tests += [['eqp', 'eqpt_c', files('C/eqpt.c')],
                     ['eqp', 'eqptf_c', files('C/eqptf.c')]]
+
+galahad_python_tests += [['eqp', 'eqp_py', files('Python/test_eqp.py')]]
 
 galahad_examples += [['eqps', files('eqps.f90')]]

--- a/src/fdc/meson.build
+++ b/src/fdc/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/fdc_pyiface.c')
+  libgalahad_python_src += [['fdc', files('Python/fdc_pyiface.c')]]
 endif
 
 galahad_tests += [['fdc', 'fdct', files('fdct.F90')],

--- a/src/fdc/meson.build
+++ b/src/fdc/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('fdc.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/fdc_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/fdc_pyiface.c')
 endif
 
 galahad_tests += [['fdc', 'fdct', files('fdct.F90')],
@@ -8,5 +13,7 @@ galahad_tests += [['fdc', 'fdct', files('fdct.F90')],
 
 galahad_c_tests += [['fdc', 'fdct_c', files('C/fdct.c')],
                     ['fdc', 'fdctf_c', files('C/fdctf.c')]]
+
+galahad_python_tests += [['fdc', 'fdc_py', files('Python/test_fdc.py')]]
 
 galahad_examples += [['fdcs', files('fdcs.f90')]]

--- a/src/fit/meson.build
+++ b/src/fit/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('fit.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/fit_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['fit', files('Python/fit_pyiface.c')]]
+endif
+
 galahad_tests += [['fit', 'fitt', files('fitt.F90')]]
+
+galahad_python_tests += [['fit', 'fit_py', files('Python/test_fit.py')]]
 
 galahad_examples += [['fits', files('fits.f90')]]

--- a/src/glrt/meson.build
+++ b/src/glrt/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/glrt_pyiface.c')
+  libgalahad_python_src += [['glrt', files('Python/glrt_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/glrt/meson.build
+++ b/src/glrt/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('glrt.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/glrt_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/glrt_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useglrt.F90', 'runglrt_sif.F90')
 endif
@@ -9,5 +15,7 @@ endif
 galahad_tests += [['glrt', 'glrtt', files('glrtt.F90')]]
 
 galahad_c_tests += [['glrt', 'glrtt_c', files('C/glrtt.c')]]
+
+galahad_python_tests += [['glrt', 'glrt_py', files('Python/test_glrt.py')]]
 
 galahad_examples += [['glrts', files('glrts.f90')]]

--- a/src/gls/meson.build
+++ b/src/gls/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/gls_pyiface.c')
+  libgalahad_python_src += [['gls', files('Python/gls_pyiface.c')]]
 endif
 
 galahad_tests += [['gls', 'glst', files('glst.F90')]]

--- a/src/gls/meson.build
+++ b/src/gls/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('gls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/gls_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += files('Python/gls_pyiface.c')
+endif
+
 galahad_tests += [['gls', 'glst', files('glst.F90')]]
+
+galahad_python_tests += [['gls', 'gls_py', files('Python/test_gls.py')]]
 
 galahad_examples += [['glss', files('glss.f90')]]

--- a/src/gltr/meson.build
+++ b/src/gltr/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('gltr.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/gltr_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/gltr_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usegltr.F90', 'rungltr_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['gltr', 'gltrt', files('gltrt.F90')],
                   ['gltr', 'gltrti', files('gltrti.F90')]]
 
 galahad_c_tests += [['gltr', 'gltrt_c', files('C/gltrt.c')]]
+
+galahad_python_tests += [['gltr', 'gltr_py', files('Python/test_gltr.py')]]
 
 galahad_examples += [['gltrs', files('gltrs.f90')],
                      ['gltrs2', files('gltrs2.f90')],

--- a/src/gltr/meson.build
+++ b/src/gltr/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/gltr_pyiface.c')
+  libgalahad_python_src += [['gltr', files('Python/gltr_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/hash/meson.build
+++ b/src/hash/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('hash.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/hash_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['hash', files('Python/hash_pyiface.c')]]
+endif
+
 galahad_tests += [['hash', 'hasht', files('hasht.F90')]]
+
+galahad_python_tests += [['hash', 'hash_py', files('Python/test_hash.py')]]
 
 galahad_examples += [['hashs', files('hashs.f90')]]

--- a/src/ir/meson.build
+++ b/src/ir/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('ir.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/ir_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['ir', files('Python/ir_pyiface.c')]]
+endif
+
 galahad_tests += [['ir', 'irt', files('irt.F90')]]
+
+galahad_python_tests += [['ir', 'ir_py', files('Python/test_ir.py')]]
 
 galahad_examples += [['irs', files('irs.f90')]]

--- a/src/l2rt/meson.build
+++ b/src/l2rt/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/l2rt_pyiface.c')
+  libgalahad_python_src += [['l2rt', files('Python/l2rt_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/l2rt/meson.build
+++ b/src/l2rt/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('l2rt.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/l2rt_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/l2rt_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usel2rt.F90', 'runl2rt_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['l2rt', 'l2rtt', files('l2rtt.F90')],
                   ['l2rt', 'l2rtti', files('l2rtti.F90')]]
 
 galahad_c_tests += [['l2rt', 'l2rtt_c', files('C/l2rtt.c')]]
+
+galahad_python_tests += [['l2rt', 'l2rt_py', files('Python/test_l2rt.py')]]
 
 galahad_examples += [['l2rts', files('l2rts.f90')],
                      ['l2rts2', files('l2rts2.f90')]]

--- a/src/lhs/meson.build
+++ b/src/lhs/meson.build
@@ -1,11 +1,18 @@
 libgalahad_src += files('lhs.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lhs_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['lhs', files('Python/lhs_pyiface.c')]]
 endif
 
 galahad_tests += [['lhs', 'lhst', files('lhst.F90')]]
 
 galahad_c_tests += [['lhs', 'lhst_c', files('C/lhst.c')]]
+
+galahad_python_tests += [['lhs', 'lhs_py', files('Python/test_lhs.py')]]
 
 galahad_examples += [['lhss', files('lhss.f90')]]
 

--- a/src/llst/meson.build
+++ b/src/llst/meson.build
@@ -4,11 +4,17 @@ if build_ciface
   libgalahad_c_src += files('C/llst_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['llst', files('Python/llst_pyiface.c')]]
+endif
+
 galahad_tests += [['llst', 'llstt', files('llstt.F90')],
                   ['llst', 'llstti', files('llstti.F90')]]
 
 galahad_c_tests += [['llst', 'llstt_c', files('C/llstt.c')],
                     ['llst', 'llsttf_c', files('C/llsttf.c')]]
+
+galahad_python_tests += [['llst', 'llst_py', files('Python/test_llst.py')]]
 
 galahad_examples += [['llsts', files('llsts.f90')],
                      ['llsts2', files('llsts2.f90')],

--- a/src/lms/meson.build
+++ b/src/lms/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('lms.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lms_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['lms', files('Python/lms_pyiface.c')]]
+endif
+
 galahad_tests += [['lms', 'lmst', files('lmst.F90')]]
+
+galahad_python_tests += [['lms', 'lms_py', files('Python/test_lms.py')]]
 
 galahad_examples += [['lmss', files('lmss.f90')]]

--- a/src/lpa/meson.build
+++ b/src/lpa/meson.build
@@ -1,10 +1,17 @@
 libgalahad_src += files('lpa.F90')
+
 galahad_binaries += [['inlpa', files('inlpa.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/lpa_ciface.F90')
 endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselpa.F90', 'runlpa_sif.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/lpa_pyiface.c')
 endif
 
 galahad_tests += [['lpa', 'lpat', files('lpat.F90')],
@@ -12,5 +19,7 @@ galahad_tests += [['lpa', 'lpat', files('lpat.F90')],
 
 galahad_c_tests += [['lpa', 'lpat_c', files('C/lpat.c')],
                     ['lpa', 'lpatf_c', files('C/lpatf.c')]]
+
+galahad_python_tests += [['lpa', 'lpa_py', files('Python/test_lpa.py')]]
 
 galahad_examples += [['lpas', files('lpas.f90')]]

--- a/src/lpa/meson.build
+++ b/src/lpa/meson.build
@@ -6,12 +6,12 @@ if build_ciface
   libgalahad_c_src += files('C/lpa_ciface.F90')
 endif
 
-if libcutest.found()
-  libgalahad_cutest_src += files('uselpa.F90', 'runlpa_sif.F90')
+if build_pythoniface
+  libgalahad_python_src += [['lpa', files('Python/lpa_pyiface.c')]]
 endif
 
-if build_pythoniface
-  libgalahad_python_src += files('Python/lpa_pyiface.c')
+if libcutest.found()
+  libgalahad_cutest_src += files('uselpa.F90', 'runlpa_sif.F90')
 endif
 
 galahad_tests += [['lpa', 'lpat', files('lpat.F90')],

--- a/src/lpb/meson.build
+++ b/src/lpb/meson.build
@@ -1,10 +1,17 @@
 libgalahad_src += files('lpb.F90')
+
 galahad_binaries += [['inlpb', files('inlpb.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/lpb_ciface.F90')
 endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselpb.F90', 'runlpb_sif.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/lpb_pyiface.c')
 endif
 
 galahad_tests += [['lpb', 'lpbt', files('lpbt.F90')],
@@ -12,5 +19,7 @@ galahad_tests += [['lpb', 'lpbt', files('lpbt.F90')],
 
 galahad_c_tests += [['lpb', 'lpbt_c', files('C/lpbt.c')],
                     ['lpb', 'lpbtf_c', files('C/lpbtf.c')]]
+
+galahad_python_tests += [['lpb', 'lpb_py', files('Python/test_lpb.py')]]
 
 galahad_examples += [['lpbs', files('lpbs.f90')]]

--- a/src/lpb/meson.build
+++ b/src/lpb/meson.build
@@ -6,12 +6,12 @@ if build_ciface
   libgalahad_c_src += files('C/lpb_ciface.F90')
 endif
 
-if libcutest.found()
-  libgalahad_cutest_src += files('uselpb.F90', 'runlpb_sif.F90')
+if build_pythoniface
+  libgalahad_python_src += [['lpb', files('Python/lpb_pyiface.c')]]
 endif
 
-if build_pythoniface
-  libgalahad_python_src += files('Python/lpb_pyiface.c')
+if libcutest.found()
+  libgalahad_cutest_src += files('uselpb.F90', 'runlpb_sif.F90')
 endif
 
 galahad_tests += [['lpb', 'lpbt', files('lpbt.F90')],

--- a/src/lsqp/meson.build
+++ b/src/lsqp/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('lsqp.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lsqp_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/lsqp_pyiface.c')
 endif
 
 galahad_tests += [['lsqp', 'lsqpt', files('lsqpt.F90')],
@@ -8,6 +13,8 @@ galahad_tests += [['lsqp', 'lsqpt', files('lsqpt.F90')],
 
 galahad_c_tests += [['lsqp', 'lsqpt_c', files('C/lsqpt.c')],
                     ['lsqp', 'lsqptf_c', files('C/lsqptf.c')]]
+
+galahad_python_tests += [['lsqp', 'lsqp_py', files('Python/test_lsqp.py')]]
 
 galahad_examples += [['lsqps', files('lsqps.f90')],
                      ['lsqps2', files('lsqps2.f90')]]

--- a/src/lsqp/meson.build
+++ b/src/lsqp/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/lsqp_pyiface.c')
+  libgalahad_python_src += [['lsqp', files('Python/lsqp_pyiface.c')]]
 endif
 
 galahad_tests += [['lsqp', 'lsqpt', files('lsqpt.F90')],

--- a/src/lsrt/meson.build
+++ b/src/lsrt/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('lsrt.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lsrt_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/lsrt_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselsrt.F90', 'runlsrt_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['lsrt', 'lsrtt', files('lsrtt.F90')],
                   ['lsrt', 'lsrtti', files('lsrtti.F90')]]
 
 galahad_c_tests += [['lsrt', 'lsrtt_c', files('C/lsrtt.c')]]
+
+galahad_python_tests += [['lsrt', 'lsrt_py', files('Python/test_lsrt.py')]]
 
 galahad_examples += [['lsrts', files('lsrts.f90')],
                      ['lsrts2', files('lsrts2.f90')]]

--- a/src/lsrt/meson.build
+++ b/src/lsrt/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/lsrt_pyiface.c')
+  libgalahad_python_src += [['lsrt', files('Python/lsrt_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/lstr/meson.build
+++ b/src/lstr/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/lstr_pyiface.c')
+  libgalahad_python_src += [['lstr', files('Python/lstr_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/lstr/meson.build
+++ b/src/lstr/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('lstr.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lstr_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/lstr_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselstr.F90', 'runlstr_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['lstr', 'lstrt', files('lstrt.F90')],
                   ['lstr', 'lstrti', files('lstrti.F90')]]
 
 galahad_c_tests += [['lstr', 'lstrt_c', files('C/lstrt.c')]]
+
+galahad_python_tests += [['lstr', 'lstr_py', files('Python/test_lstr.py')]]
 
 galahad_examples += [['lstrs', files('lstrs.f90')],
                      ['lstrs2', files('lstrs2.f90')]]

--- a/src/nls/meson.build
+++ b/src/nls/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/nls_pyiface.c')
+  libgalahad_python_src += [['nls', files('Python/nls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/nls/meson.build
+++ b/src/nls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('nls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/nls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/nls_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usenls.F90', 'runnls_sif.F90')
 endif

--- a/src/nls/meson.build
+++ b/src/nls/meson.build
@@ -18,6 +18,8 @@ galahad_tests += [['nls', 'nlst', files('nlst.F90')],
 galahad_c_tests += [['nls', 'nlst_c', files('C/nlst.c')],
                     ['nls', 'nlstf_c', files('C/nlstf.c')]]
 
+galahad_python_tests += [['nls', 'nls_py', files('Python/test_nls.py')]]
+
 galahad_examples += [['nlss', files('nlss.f90')],
                      ['nlss2', files('nlss2.f90')],
                      ['nlss3', files('nlss3.f90')]]

--- a/src/presolve/meson.build
+++ b/src/presolve/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('presolve.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/presolve_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['presolve', files('Python/presolve_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usepresolve.F90', 'runpresolve_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['presolve', 'presolvet', files('presolvet.F90')],
 
 galahad_c_tests += [['presolve', 'presolvet_c', files('C/presolvet.c')],
                     ['presolve', 'presolvetf_c', files('C/presolvetf.c')]]
+
+galahad_python_tests += [['presolve', 'presolve_py', files('Python/test_presolve.py')]]
 
 galahad_examples += [['presolves', files('presolves.f90')]]

--- a/src/psls/meson.build
+++ b/src/psls/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('psls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/psls_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['psls', files('Python/psls_pyiface.c')]]
 endif
 
 galahad_tests += [['psls', 'pslst', files('pslst.F90')],
@@ -8,5 +13,7 @@ galahad_tests += [['psls', 'pslst', files('pslst.F90')],
 
 galahad_c_tests += [['psls', 'pslst_c', files('C/pslst.c')],
                     ['psls', 'pslstf_c', files('C/pslstf.c')]]
+
+galahad_python_tests += [['psls', 'psls_py', files('Python/test_psls.py')]]
 
 galahad_examples += [['pslss', files('pslss.f90')]]

--- a/src/qpa/meson.build
+++ b/src/qpa/meson.build
@@ -1,10 +1,17 @@
 libgalahad_src += files('qpa.F90')
+
 galahad_binaries += [['inqpa', files('inqpa.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/qpa_ciface.F90')
 endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useqpa.F90', 'runqpa_sif.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/qpa_pyiface.c')
 endif
 
 galahad_tests += [['qpa', 'qpat', files('qpat.F90')],
@@ -12,5 +19,7 @@ galahad_tests += [['qpa', 'qpat', files('qpat.F90')],
 
 galahad_c_tests += [['qpa', 'qpat_c', files('C/qpat.c')],
                     ['qpa', 'qpatf_c', files('C/qpatf.c')]]
+
+galahad_python_tests += [['qpa', 'qpa_py', files('Python/test_qpa.py')]]
 
 galahad_examples += [['qpas', files('qpas.f90')]]

--- a/src/qpa/meson.build
+++ b/src/qpa/meson.build
@@ -6,12 +6,12 @@ if build_ciface
   libgalahad_c_src += files('C/qpa_ciface.F90')
 endif
 
-if libcutest.found()
-  libgalahad_cutest_src += files('useqpa.F90', 'runqpa_sif.F90')
+if build_pythoniface
+  libgalahad_python_src += [['qpa', files('Python/qpa_pyiface.c')]]
 endif
 
-if build_pythoniface
-  libgalahad_python_src += files('Python/qpa_pyiface.c')
+if libcutest.found()
+  libgalahad_cutest_src += files('useqpa.F90', 'runqpa_sif.F90')
 endif
 
 galahad_tests += [['qpa', 'qpat', files('qpat.F90')],

--- a/src/qpb/meson.build
+++ b/src/qpb/meson.build
@@ -6,12 +6,12 @@ if build_ciface
   libgalahad_c_src += files('C/qpb_ciface.F90')
 endif
 
-if libcutest.found()
-  libgalahad_cutest_src += files('useqpb.F90', 'runqpb_sif.F90')
+if build_pythoniface
+  libgalahad_python_src += [['qpb', files('Python/qpb_pyiface.c')]]
 endif
 
-if build_pythoniface
-  libgalahad_python_src += files('Python/qpb_pyiface.c')
+if libcutest.found()
+  libgalahad_cutest_src += files('useqpb.F90', 'runqpb_sif.F90')
 endif
 
 galahad_tests += [['qpb', 'qpbt', files('qpbt.F90')],

--- a/src/qpb/meson.build
+++ b/src/qpb/meson.build
@@ -1,10 +1,17 @@
 libgalahad_src += files('qpb.F90')
+
 galahad_binaries += [['inqpb', files('inqpb.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/qpb_ciface.F90')
 endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useqpb.F90', 'runqpb_sif.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/qpb_pyiface.c')
 endif
 
 galahad_tests += [['qpb', 'qpbt', files('qpbt.F90')],
@@ -12,6 +19,8 @@ galahad_tests += [['qpb', 'qpbt', files('qpbt.F90')],
 
 galahad_c_tests += [['qpb', 'qpbt_c', files('C/qpbt.c')],
                     ['qpb', 'qpbtf_c', files('C/qpbtf.c')]]
+
+galahad_python_tests += [['qpb', 'qpb_py', files('Python/test_qpb.py')]]
 
 galahad_examples += [['qpbs', files('qpbs.f90')],
                      ['qpbs2', files('qpbs2.f90')]]

--- a/src/roots/meson.build
+++ b/src/roots/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('roots.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/roots_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['roots', files('Python/roots_pyiface.c')]]
+endif
+
 galahad_tests += [['roots', 'rootst', files('rootst.F90')]]
+
+galahad_python_tests += [['roots', 'roots_py', files('Python/test_roots.py')]]
 
 galahad_examples += [['rootss', files('rootss.f90')]]

--- a/src/rpd/meson.build
+++ b/src/rpd/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('rpd.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/rpd_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['rpd', files('Python/rpd_pyiface.c')]]
 endif
 
 galahad_tests += [['rpd', 'rpdt', files('rpdt.F90')],
@@ -8,5 +13,7 @@ galahad_tests += [['rpd', 'rpdt', files('rpdt.F90')],
 
 galahad_c_tests += [['rpd', 'rpdt_c', files('C/rpdt.c')],
                     ['rpd', 'rpdtf_c', files('C/rpdtf.c')]]
+
+galahad_python_tests += [['rpd', 'rpd_py', files('Python/test_rpd.py')]]
 
 galahad_examples += [['rpds', files('rpds.f90')]]

--- a/src/rqs/meson.build
+++ b/src/rqs/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('rqs.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/rqs_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/rqs_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('userqs.F90', 'runrqs_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['rqs', 'rqst', files('rqst.F90')],
 
 galahad_c_tests += [['rqs', 'rqst_c', files('C/rqst.c')],
                     ['rqs', 'rqstf_c', files('C/rqstf.c')]]
+
+galahad_python_tests += [['rqs', 'rqs_py', files('Python/test_rqs.py')]]
 
 galahad_examples += [['rqss', files('rqss.f90')],
                      ['rqss2', files('rqss2.f90')]]

--- a/src/rqs/meson.build
+++ b/src/rqs/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/rqs_pyiface.c')
+  libgalahad_python_src += [['rqs', files('Python/rqs_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/sbls/meson.build
+++ b/src/sbls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('sbls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sbls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['sbls', files('Python/sbls_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesbls.F90', 'runsbls_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['sbls', 'sblst', files('sblst.F90')],
 
 galahad_c_tests += [['sbls', 'sblst_c', files('C/sblst.c')],
                     ['sbls', 'sblstf_c', files('C/sblstf.c')]]
+
+galahad_python_tests += [['sbls', 'sbls_py', files('Python/test_sbls.py')]]
 
 galahad_examples += [['sblss', files('sblss.f90')]]

--- a/src/scu/meson.build
+++ b/src/scu/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('scu.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/scu_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['scu', files('Python/scu_pyiface.c')]]
+endif
+
 galahad_tests += [['scu', 'scut', files('scut.F90')]]
+
+galahad_python_tests += [['scu', 'scu_py', files('Python/test_scu.py')]]
 
 galahad_examples += [['scus', files('scus.f90')]]

--- a/src/sec/meson.build
+++ b/src/sec/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('sec.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sec_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['sec', files('Python/sec_pyiface.c')]]
+endif
+
 galahad_tests += [['sec', 'sect', files('sect.F90')]]
+
+galahad_python_tests += [['sec', 'sec_py', files('Python/test_sec.py')]]
 
 galahad_examples += [['secs', files('secs.f90')]]

--- a/src/sha/meson.build
+++ b/src/sha/meson.build
@@ -1,11 +1,19 @@
 libgalahad_src += files('sha.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sha_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['sha', files('Python/sha_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesha.F90', 'runsha_sif.F90')
 endif
 
 galahad_tests += [['sha', 'shat', files('shat.F90')]]
+
+galahad_python_tests += [['sha', 'sha_py', files('Python/test_sha.py')]]
 
 galahad_examples += [['shas', files('shas.f90')]]

--- a/src/sils/meson.build
+++ b/src/sils/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/sils_pyiface.c')
+  libgalahad_python_src += [['sils', files('Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/sils/meson.build
+++ b/src/sils/meson.build
@@ -1,11 +1,19 @@
 libgalahad_src += files('sils.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sils_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/sils_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesils.F90', 'runsils_sif.F90')
 endif
 
 galahad_tests += [['sils', 'silst', files('silst.F90')]]
+
+galahad_python_tests += [['sils', 'sils_py', files('Python/test_sils.py')]]
 
 galahad_examples += [['silss', files('silss.f90')]]

--- a/src/sls/meson.build
+++ b/src/sls/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/sls_pyiface.c')
+  libgalahad_python_src += [['sls', files('Python/sls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/sls/meson.build
+++ b/src/sls/meson.build
@@ -18,4 +18,6 @@ galahad_tests += [['sls', 'slst', files('slst.F90')],
 galahad_c_tests += [['sls', 'slst_c', files('C/slst.c')],
                     ['sls', 'slstf_c', files('C/slstf.c')]]
 
+galahad_python_tests += [['sls', 'sls_py', files('Python/test_sls.py')]]
+
 galahad_examples += [['slss', files('slss.f90')]]

--- a/src/sls/meson.build
+++ b/src/sls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('sls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/sls_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesls.F90', 'runsls_sif.F90')
 endif

--- a/src/trb/meson.build
+++ b/src/trb/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/trb_pyiface.c')
+  libgalahad_python_src += [['trb', files('Python/trb_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/trb/meson.build
+++ b/src/trb/meson.build
@@ -18,6 +18,8 @@ galahad_tests += [['trb', 'trbt', files('trbt.F90')],
 galahad_c_tests += [['trb', 'trbt_c', files('C/trbt.c')],
                     ['trb', 'trbtf_c', files('C/trbtf.c')]]
 
+galahad_python_tests += [['trb', 'trb_py', files('Python/test_trb.py')]]
+
 galahad_examples += [['trbs', files('trbs.f90')],
                      ['trbs2', files('trbs2.f90')],
                      ['trbs3', files('trbs3.f90')]]

--- a/src/trb/meson.build
+++ b/src/trb/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('trb.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/trb_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/trb_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usetrb.F90', 'runtrb_sif.F90')
 endif

--- a/src/trs/meson.build
+++ b/src/trs/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/trs_pyiface.c')
+  libgalahad_python_src += [['trs', files('Python/trs_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/trs/meson.build
+++ b/src/trs/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('trs.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/trs_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/trs_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usetrs.F90', 'runtrs_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['trs', 'trst', files('trst.F90')],
 
 galahad_c_tests += [['trs', 'trst_c', files('C/trst.c')],
                     ['trs', 'trstf_c', files('C/trstf.c')]]
+
+galahad_python_tests += [['trs', 'trs_py', files('Python/test_trs.py')]]
 
 galahad_examples += [['trss', files('trss.f90')],
                      ['trss2', files('trss2.f90')]]

--- a/src/tru/meson.build
+++ b/src/tru/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('tru.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/tru_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/tru_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usetru.F90', 'runtru_sif.F90')
 endif

--- a/src/tru/meson.build
+++ b/src/tru/meson.build
@@ -18,6 +18,8 @@ galahad_tests += [['tru', 'trut', files('trut.F90')],
 galahad_c_tests += [['tru', 'trut_c', files('C/trut.c')],
                     ['tru', 'trutf_c', files('C/trutf.c')]]
 
+galahad_python_tests += [['tru', 'tru_py', files('Python/test_tru.py')]]
+
 galahad_examples += [['trus', files('trus.f90')],
                      ['trus2', files('trus2.f90')],
                      ['trus3', files('trus3.f90')],

--- a/src/tru/meson.build
+++ b/src/tru/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/tru_pyiface.c')
+  libgalahad_python_src += [['tru', files('Python/tru_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/ugo/meson.build
+++ b/src/ugo/meson.build
@@ -16,6 +16,8 @@ galahad_tests += [['ugo', 'ugot', files('ugot.F90')]]
 
 galahad_c_tests += [['ugo', 'ugot_c', files('C/ugot.c')]]
 
+galahad_python_tests += [['ugo', 'ugo_py', files('Python/test_ugo.py')]]
+
 galahad_examples += [['ugos', files('ugos.f90')],
                      ['ugos2', files('ugos2.f90')],
                      ['ugos3', files('ugos3.f90')]]

--- a/src/ugo/meson.build
+++ b/src/ugo/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('ugo.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/ugo_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/ugo_pyiface.c')
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useugo.F90', 'runugo_sif.F90')
 endif

--- a/src/ugo/meson.build
+++ b/src/ugo/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/ugo_pyiface.c')
+  libgalahad_python_src += [['ugo', files('Python/ugo_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/uls/meson.build
+++ b/src/uls/meson.build
@@ -5,7 +5,7 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += files('Python/uls_pyiface.c')
+  libgalahad_python_src += [['uls', files('Python/uls_pyiface.c')]]
 endif
 
 galahad_tests += [['uls', 'ulst', files('ulst.F90')],

--- a/src/uls/meson.build
+++ b/src/uls/meson.build
@@ -14,4 +14,6 @@ galahad_tests += [['uls', 'ulst', files('ulst.F90')],
 galahad_c_tests += [['uls', 'ulst_c', files('C/ulst.c')],
                     ['uls', 'ulstf_c', files('C/ulstf.c')]]
 
+galahad_python_tests += [['uls', 'uls_py', files('Python/test_uls.py')]]
+
 galahad_examples += [['ulss', files('ulss.f90')]]

--- a/src/uls/meson.build
+++ b/src/uls/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('uls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/uls_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += files('Python/uls_pyiface.c')
 endif
 
 galahad_tests += [['uls', 'ulst', files('ulst.F90')],

--- a/src/wcp/meson.build
+++ b/src/wcp/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('wcp.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/wcp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['wcp', files('Python/wcp_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usewcp.F90', 'runwcp_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['wcp', 'wcpt', files('wcpt.F90')],
 
 galahad_c_tests += [['wcp', 'wcpt_c', files('C/wcpt.c')],
                     ['wcp', 'wcptf_c', files('C/wcptf.c')]]
+
+galahad_python_tests += [['wcp', 'wcp_py', files('Python/test_wcp.py')]]
 
 galahad_examples += [['wcps', files('wcps.f90')]]


### PR DESCRIPTION
@nimgould @jfowkes 
I added an option to compile the Python interface with Meson this morning, but I have the following error:
```shell
ninja: Entering directory `/home/alexis/Bureau/git/GALAHAD/builddir'
[1/1867] Compiling C object libgalahad_python.so.p/src_ugo_Python_ugo_pyiface.c.o
FAILED: libgalahad_python.so.p/src_ugo_Python_ugo_pyiface.c.o 
cc -Ilibgalahad_python.so.p -I. -I.. -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -g -fPIC -MD -MQ libgalahad_python.so.p/src_ugo_Python_ugo_pyiface.c.o -MF libgalahad_python.so.p/src_ugo_Python_ugo_pyiface.c.o.d -o libgalahad_python.so.p/src_ugo_Python_ugo_pyiface.c.o -c ../src/ugo/Python/ugo_pyiface.c
In file included from ../src/ugo/Python/ugo_pyiface.c:18:
../include/galahad_python.h:11:10: fatal error: Python.h: Aucun fichier ou dossier de ce type
   11 | #include <Python.h>
      |          ^~~~~~~~~~
compilation terminated.
[2/1867] Compiling C object libgalahad_python.so.p/src_trb_Python_trb_pyiface.c.o
FAILED: libgalahad_python.so.p/src_trb_Python_trb_pyiface.c.o 
cc -Ilibgalahad_python.so.p -I. -I.. -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -g -fPIC -MD -MQ libgalahad_python.so.p/src_trb_Python_trb_pyiface.c.o -MF libgalahad_python.so.p/src_trb_Python_trb_pyiface.c.o.d -o libgalahad_python.so.p/src_trb_Python_trb_pyiface.c.o -c ../src/trb/Python/trb_pyiface.c
In file included from ../src/trb/Python/trb_pyiface.c:18:
../include/galahad_python.h:11:10: fatal error: Python.h: Aucun fichier ou dossier de ce type
   11 | #include <Python.h>
      |          ^~~~~~~~~~
compilation terminated.
[6/1867] Compiling Fortran object libgalahad_hsl_double.so.p/src_zd11_zd11.F90.o
ninja: build stopped: subcommand failed.
```

Can you also explain how to compile the Python tests?