### PR TITLE
[Meson] Link GALAHAD with JuliaHSL

### DIFF
--- a/include/hsl_mc68.h
+++ b/include/hsl_mc68.h
@@ -58,7 +58,7 @@ struct mc68_control {
    int f_array_out;     /* 0 for C array indexing, 1 for Fortran indexing
                          * NOTE: 2x2 pivot information discarded if C indexing
                          * is used for output! */
-   long min_l_workspace; /* Initial size of workspace, as argument in Fortran */
+   int min_l_workspace; /* Initial size of workspace, as argument in Fortran */
    /* Options from Fortran version */
    int lp;              /* stream number for error messages */
    int wp;              /* stream number for warning messages */

--- a/meson.build
+++ b/meson.build
@@ -71,6 +71,8 @@ libpastix_path = get_option('libpastix_path')
 libmkl_pardiso_path = get_option('libmkl_pardiso_path')
 libampl_path = get_option('libampl_path')
 
+libhsl_modules = get_option('libhsl_modules')
+
 # Dependencies
 libblas = fc.find_library(libblas_name, dirs : libblas_path, required : false)
 liblapack = fc.find_library(liblapack_name, dirs : liblapack_path, required : false)
@@ -119,7 +121,8 @@ galahad_c_examples = []
 galahad_tests = []
 galahad_c_tests = []
 
-libgalahad_include = ['include', 'src/dum/include', 'src/ampl']
+# Headers and Fortran modules
+libgalahad_include = ['include', 'src/dum/include', 'src/ampl'] + libhsl_modules
 
 # TODO: -DSPRAL_NO_SCHED_GETCPU | DSPRAL_HAVE_SCHED_GETCPU
 extra_args = ['-DSPRAL_NO_SCHED_GETCPU']
@@ -293,6 +296,7 @@ foreach val: galahad_binaries
 
   if build_single
     executable(binname+'_single', binfile,
+               dependencies : libgalahad_single_deps + libgalahad_deps,
                fortran_args : extra_args_single,
                link_with : libgalahad_single,
                link_language : 'fortran',
@@ -301,6 +305,7 @@ foreach val: galahad_binaries
   endif
   if build_double
     executable(binname+'_double', binfile,
+               dependencies : libgalahad_double_deps + libgalahad_deps,
                fortran_args : extra_args_double,
                link_with : libgalahad_double,
                link_language : 'fortran',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,6 +33,11 @@ option('double',
        value : true,
        description : 'whether to generate the double precision libraries, tests and examples')
 
+option('ssids',
+       type : 'boolean',
+       value : false,
+       description : 'whether to build ssids as well as the related tests and examples')
+
 option('libblas',
        type : 'string',
        value : 'blas',
@@ -158,7 +163,7 @@ option('libampl_path',
        value : [],
        description : 'Additional directories to search AMPL library library')
 
-option('ssids',
-       type : 'boolean',
-       value : false,
-       description : 'whether to build ssids as well as the related tests and examples')
+option('libhsl_modules',
+       type : 'array',
+       value : [],
+       description : 'Additional directories to search HSL modules')


### PR DESCRIPTION
I tested the compilation of GALAHAD with JuliaHSL tonight and it worked. :100: 

```shell
meson setup builddir_julia --prefix=~/Applications/galahad \
                           -Dmodules=true \
                           -Dlibhsl_path=/home/alexis/Applications/juliahsl/lib \
                           -Dlibhsl_modules=/home/alexis/Applications/juliahsl/modules \
                           -Dlibmetis_path=/home/alexis/Applications/metis-5.1.0/install/lib
```

ps: I also updated the header file of `hsl_mc68`.