### PR TITLE
Support METIS 5 in GALAHAD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -131,7 +131,7 @@ galahad_c_tests = []
 # Headers and Fortran modules
 libgalahad_include = [include_directories('include'),
                       include_directories('src/dum/include'),
-                      include_directories('src/ampl')] + libhsl_modules
+                      include_directories('src/ampl')] + libmetis_include + libhsl_modules
 
 # TODO: -DSPRAL_NO_SCHED_GETCPU | DSPRAL_HAVE_SCHED_GETCPU
 extra_args = ['-DSPRAL_NO_SCHED_GETCPU']

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,9 @@ libpastix_path = get_option('libpastix_path')
 libmkl_pardiso_path = get_option('libmkl_pardiso_path')
 libampl_path = get_option('libampl_path')
 
+libmetis_include = get_option('libmetis_include')
+libmetis_version = get_option('libmetis_version')
+
 libhsl_modules = get_option('libhsl_modules')
 
 # Dependencies

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -167,3 +167,14 @@ option('libhsl_modules',
        type : 'array',
        value : [],
        description : 'Additional directories to search HSL modules')
+
+option('libmetis_include',
+       type : 'array',
+       value : [],
+       description : 'Additional directories to search the METIS header files')
+
+option('libmetis_version',
+       type : 'combo',
+       choices : ['4', '5'],
+       value : '5',
+       description : 'Version of the METIS library')

--- a/src/dum/meson.build
+++ b/src/dum/meson.build
@@ -36,10 +36,6 @@ if not libhsl.found()
   libgalahad_integer_src += files('hsl_kb22l.f90', 'hsl_mc68i.f90', 'hsl_mc78i.f90', 'hsl_of01i.f90', 'hsl_zb01i.f90', 'kb07i.f')
 endif
 
-if not libmetis.found()
-  libgalahad_src += files('metis4.f')
-endif
-
 if not libwsmp.found()
   libgalahad_src += files('wsmp.F90')
 endif

--- a/src/dum/metis4.f
+++ b/src/dum/metis4.f
@@ -1,7 +1,0 @@
-      SUBROUTINE METIS_NODEND(N,IPTR,IRN,METFTN,METOPT,INVPRM,PERM)
-C Dummy routine that is called if MeTiS (version 4) is not linked.
-      INTEGER N
-      INTEGER IPTR(N+1),IRN(*),METFTN,METOPT(8),INVPRM(N),PERM(N)
-      PERM(1) = -1
-      RETURN
-      END

--- a/src/external/meson.build
+++ b/src/external/meson.build
@@ -1,3 +1,5 @@
+subdir('metis')
+
 libgalahad_src += files('mkl_pardiso/mkl_pardiso_interface.F90', 'mumps/mumps_types.F90',
                         'pastix/spmf_interfaces.F90', 'pastix/pastixf_interfaces.F90')
 

--- a/src/external/metis/dummy_metis.f90
+++ b/src/external/metis/dummy_metis.f90
@@ -1,0 +1,14 @@
+! Dummy routine that is called if MeTiS is not linked.
+subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
+    implicit none
+    integer, intent(in) :: n
+    integer, intent(in) :: iptr(n+1)
+    integer, intent(in) :: irn(*)
+    integer, intent(in) :: metftn
+    integer, intent(in) :: metopt(8)
+    integer, intent(out) :: invprm(n)
+    integer, intent(out) :: perm(n)
+
+    ! Dummy ordering
+    perm(1) = -1
+end subroutine juliahsl_metis

--- a/src/external/metis/dummy_metis.f90
+++ b/src/external/metis/dummy_metis.f90
@@ -1,5 +1,5 @@
 ! Dummy routine that is called if MeTiS is not linked.
-subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
+subroutine galahad_metis(n,iptr,irn,metftn,metopt,invprm,perm)
     implicit none
     integer, intent(in) :: n
     integer, intent(in) :: iptr(n+1)
@@ -11,4 +11,4 @@ subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
 
     ! Dummy ordering
     perm(1) = -1
-end subroutine juliahsl_metis
+end subroutine galahad_metis

--- a/src/external/metis/meson.build
+++ b/src/external/metis/meson.build
@@ -1,5 +1,11 @@
+if libmetis_include != []
+  foreach folder: libmetis_include
+    pp_options += ['-I', folder]
+  endforeach
+endif
+
 if not (libmetis.found() and libmetis_version == '4')
-  add_global_arguments('-Dmetis_nodend=juliahsl_metis', language : 'fortran')
+  add_global_arguments('-Dmetis_nodend=galahad_metis', language : 'fortran')
 endif
 
 if libmetis.found() and libmetis_version == '4'

--- a/src/external/metis/meson.build
+++ b/src/external/metis/meson.build
@@ -1,0 +1,11 @@
+if not (libmetis.found() and libmetis_version == '4')
+  add_global_arguments(['-Dmetis_nodend=juliahsl_metis', '-DMETIS_NODEND=juliahsl_metis'], language : 'fortran')
+endif
+
+if libmetis.found() and libmetis_version == '4'
+  libhsl_src += files('metis4.f90')
+elif libmetis.found() and libmetis_version == '5'
+  libhsl_src += files('metis5_adapter.c', 'metis5.f90')
+else
+  libhsl_src += files('dummy_metis.f90')
+endif

--- a/src/external/metis/meson.build
+++ b/src/external/metis/meson.build
@@ -1,11 +1,11 @@
 if not (libmetis.found() and libmetis_version == '4')
-  add_global_arguments(['-Dmetis_nodend=juliahsl_metis', '-DMETIS_NODEND=juliahsl_metis'], language : 'fortran')
+  add_global_arguments('-Dmetis_nodend=juliahsl_metis', language : 'fortran')
 endif
 
 if libmetis.found() and libmetis_version == '4'
-  libhsl_src += files('metis4.f90')
+  libgalahad_src += files('metis4.f90')
 elif libmetis.found() and libmetis_version == '5'
-  libhsl_src += files('metis5_adapter.c', 'metis5.f90')
+  libgalahad_src += files('metis5_adapter.c', 'metis5.f90')
 else
-  libhsl_src += files('dummy_metis.f90')
+  libgalahad_src += files('dummy_metis.f90')
 endif

--- a/src/external/metis/metis4.f90
+++ b/src/external/metis/metis4.f90
@@ -1,0 +1,14 @@
+! Routine that is called if MeTiS 4 is linked.
+subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
+    implicit none
+    integer, intent(in) :: n
+    integer, intent(in) :: iptr(n+1)
+    integer, intent(in) :: irn(*)
+    integer, intent(in) :: metftn
+    integer, intent(in) :: metopt(8)
+    integer, intent(out) :: invprm(n)
+    integer, intent(out) :: perm(n)
+
+    ! Call MeTiS 4 to get ordering
+    call metis_nodend(n,iptr,irn,metftn,metopt,invprm,perm)
+end subroutine juliahsl_metis

--- a/src/external/metis/metis4.f90
+++ b/src/external/metis/metis4.f90
@@ -1,5 +1,5 @@
 ! Routine that is called if MeTiS 4 is linked.
-subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
+subroutine galahad_metis(n,iptr,irn,metftn,metopt,invprm,perm)
     implicit none
     integer, intent(in) :: n
     integer, intent(in) :: iptr(n+1)
@@ -11,4 +11,4 @@ subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
 
     ! Call MeTiS 4 to get ordering
     call metis_nodend(n,iptr,irn,metftn,metopt,invprm,perm)
-end subroutine juliahsl_metis
+end subroutine galahad_metis

--- a/src/external/metis/metis5.f90
+++ b/src/external/metis/metis5.f90
@@ -1,0 +1,26 @@
+! Routine that is called if MeTiS 5 is linked.
+subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
+    implicit none
+    integer, intent(in) :: n
+    integer, intent(in) :: iptr(n+1)
+    integer, intent(in) :: irn(*)
+    integer, intent(in) :: metftn
+    integer, intent(in) :: metopt(8)
+    integer, intent(out) :: invprm(n)
+    integer, intent(out) :: perm(n)
+
+    ! C interface for MeTiS 4 to 5 adapter
+    interface
+        subroutine metis5_adapter(nvtxs, xadj, adjncy, numflag, options, &
+                                  perm, iperm) bind(C)
+            use iso_c_binding
+            implicit none
+            integer(c_int), intent(in) :: nvtxs, numflag
+            integer(c_int), dimension(*), intent(in) :: xadj, adjncy, options
+            integer(c_int), dimension(*), intent(out) :: perm, iperm
+        end subroutine metis5_adapter
+    end interface
+
+    ! Call MeTiS 5 to get ordering via C MeTiS 4 to 5 adapter
+    call metis5_adapter(n,iptr,irn,metftn,metopt,invprm,perm)
+end subroutine juliahsl_metis

--- a/src/external/metis/metis5.f90
+++ b/src/external/metis/metis5.f90
@@ -1,5 +1,5 @@
 ! Routine that is called if MeTiS 5 is linked.
-subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
+subroutine galahad_metis(n,iptr,irn,metftn,metopt,invprm,perm)
     implicit none
     integer, intent(in) :: n
     integer, intent(in) :: iptr(n+1)
@@ -23,4 +23,4 @@ subroutine juliahsl_metis(n,iptr,irn,metftn,metopt,invprm,perm)
 
     ! Call MeTiS 5 to get ordering via C MeTiS 4 to 5 adapter
     call metis5_adapter(n,iptr,irn,metftn,metopt,invprm,perm)
-end subroutine juliahsl_metis
+end subroutine galahad_metis

--- a/src/external/metis/metis5_adapter.c
+++ b/src/external/metis/metis5_adapter.c
@@ -1,0 +1,71 @@
+/* Copyright (C) 2020 COIN-OR
+ * All Rights Reserved.
+ * This file is distributed under the Eclipse Public License.
+ */
+#include "metis.h" /* from MeTiS 5 */
+
+void metis5_adapter(int* nvtxs, int* xadj, int* adjncy, int* numflag,
+                    int* options, int* perm, int* iperm){
+    int options5[METIS_NOPTIONS];
+
+    /* Handle MA57 pathological case */
+    if(*nvtxs == 1){
+        /* MA57 seems to call metis with a graph containing 1 vertex and
+         * a self-loop. Metis5 prints an error for this.
+         */
+        perm[0] = *numflag;
+        iperm[0] = *numflag;
+        return;
+    }
+
+    /* Set default MeTiS 5 options */
+    METIS_SetDefaultOptions(options5);
+    options5[METIS_OPTION_NUMBERING] = *numflag;
+
+    /* Translate MeTiS 4 options MeTiS 5 options */
+    if(options[0] != 0){
+        if(options[1] == 1) /* random matching */
+            options5[METIS_OPTION_CTYPE] = METIS_CTYPE_RM;
+        else /* heavy-edge or sorted heavy-edge matching; map both to shem,
+                as heave-edge matching not available in metis5 */
+            options5[METIS_OPTION_CTYPE] = METIS_CTYPE_SHEM;
+
+        if(options[2] == 1) /* edge-based region-growing */
+            options5[METIS_OPTION_IPTYPE] = METIS_IPTYPE_GROW;  /* ?? */
+        else /* node-based region-growing */
+            options5[METIS_OPTION_IPTYPE] = METIS_IPTYPE_NODE;
+
+        if(options[3] == 1) /* two-sided node FM refinement */
+            options5[METIS_OPTION_RTYPE] = METIS_RTYPE_SEP2SIDED;
+        else  /* one-sided node FM refinement */
+            options5[METIS_OPTION_RTYPE] = METIS_RTYPE_SEP1SIDED;
+
+        options5[METIS_OPTION_DBGLVL] = options[4];
+
+        switch(options[5]){
+            case 0:  /* do not try to compress or order connected components */
+                options5[METIS_OPTION_COMPRESS] = 0;
+                options5[METIS_OPTION_CCORDER] = 0;
+                break;
+            case 1:  /* try to compress graph */
+                options5[METIS_OPTION_COMPRESS] = 1;
+                options5[METIS_OPTION_CCORDER] = 0;
+                break;
+            case 2:  /* order each component separately */
+                options5[METIS_OPTION_COMPRESS] = 0;
+                options5[METIS_OPTION_CCORDER] = 1;
+                break;
+            case 3:  /* try to compress and order components */
+                options5[METIS_OPTION_COMPRESS] = 1;
+                options5[METIS_OPTION_CCORDER] = 1;
+                break;
+        }
+
+        options5[METIS_OPTION_PFACTOR] = options[6];
+
+        options5[METIS_OPTION_NSEPS] = options[7];
+    }
+
+    /* Call MeTiS 5 to get ordering */
+    METIS_NodeND(nvtxs, xadj, adjncy, (void*)0, options5, perm, iperm);
+}


### PR DESCRIPTION
In brief, I use fortran preprocessing to replace `metis_nodend` by `galahad_metis`.
We have three versions of `galahad_metis` (dummy, metis4, metis5).
They are based on the API of METIS 4 so we don't need to update the source code of GALAHAD.

I removed `src/dum/metis4.f` because it's replaced by `src/external/metis/dummy_metis.f90`.