### PR TITLE
The default shared library for libmkl_pardiso is mkl_rt

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -90,7 +90,7 @@ option('libpastix',
 
 option('libmkl_pardiso',
        type : 'string',
-       value : 'mkl_intel_lp64',
+       value : 'mkl_rt',
        description : 'option for Intel MKL PARDISO library switching')
 
 option('libampl',


### PR DESCRIPTION
@nimgould 
We can use the library `libmkl_rt.so` to link with all functions of oneMKL.