### PR TITLE
Use BLAS and LAPACK routines provided by GALAHAD for CI builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,9 +16,9 @@ task:
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
-      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad
+      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dlibblas= -Dliblapack=
     else
-      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad
+      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad -Dlibblas= -Dliblapack=
     fi
   build_script: |
     meson compile -C builddir

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad
+          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dlibblas= -Dliblapack=
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}


### PR DESCRIPTION
It seems that some platforms find `libblas.${dlext}` and  `liblapack.${dlext}`.
It could explain why we have tests that fail only on some platforms.