### PR TITLE
Remove the option to provide the header of METIS5

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,6 @@ libpastix_path = get_option('libpastix_path')
 libmkl_pardiso_path = get_option('libmkl_pardiso_path')
 libampl_path = get_option('libampl_path')
 
-libmetis_include = get_option('libmetis_include')
 libmetis_version = get_option('libmetis_version')
 
 libhsl_modules = get_option('libhsl_modules')
@@ -131,7 +130,7 @@ galahad_c_tests = []
 # Headers and Fortran modules
 libgalahad_include = [include_directories('include'),
                       include_directories('src/dum/include'),
-                      include_directories('src/ampl')] + libmetis_include + libhsl_modules
+                      include_directories('src/ampl')] + libhsl_modules
 
 # TODO: -DSPRAL_NO_SCHED_GETCPU | DSPRAL_HAVE_SCHED_GETCPU
 extra_args = ['-DSPRAL_NO_SCHED_GETCPU']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -168,11 +168,6 @@ option('libhsl_modules',
        value : [],
        description : 'Additional directories to search HSL modules')
 
-option('libmetis_include',
-       type : 'array',
-       value : [],
-       description : 'Additional directories to search the METIS header files')
-
 option('libmetis_version',
        type : 'combo',
        choices : ['4', '5'],

--- a/src/external/metis/meson.build
+++ b/src/external/metis/meson.build
@@ -1,9 +1,3 @@
-if libmetis_include != []
-  foreach folder: libmetis_include
-    pp_options += ['-I', folder]
-  endforeach
-endif
-
 if not (libmetis.found() and libmetis_version == '4')
   add_global_arguments('-Dmetis_nodend=galahad_metis', language : 'fortran')
 endif


### PR DESCRIPTION
Nick added the header `metis.h` of METIS 5 in `include`, we don't need anymore to provide a path to find it.