### PR TITLE
Update how we preprocess Fortran files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,13 +39,10 @@ endif
 pp_options = []
 if fc.get_id() == 'gcc'
   pp_options += ['-cpp', '-E']
-  add_global_arguments('-cpp', language : 'fortran')
 elif fc.get_id() == 'intel' or fc.get_id() == 'intel-cl'
   pp_options += ['-fpp', '-P']
-  add_global_arguments('-fpp', language : 'fortran')
 elif fc.get_id() == 'nagfor'
   pp_options += ['-fpp', '-F']
-  add_global_arguments('-fpp', language : 'fortran')
 endif
 
 # Options
@@ -115,6 +112,14 @@ elif fc.get_id() == 'gcc'
 elif fc.get_id() == 'intel' or fc.get_id() == 'intel-cl'
   add_global_link_arguments('-qopenmp', language : 'fortran')
 endif
+
+if cxx.get_id() == 'gcc'
+  add_global_arguments('-fopenmp', language : 'cpp')
+endif
+# --- FIX ME ---
+# if cxx.get_id() == 'intel' or cxx.get_id() == 'intel-cl'
+#   add_global_arguments('-qopenmp', language : 'cpp')
+# endif
 
 libmpi = dependency('mpi', language : 'fortran', required : false)
 libhwloc = dependency('hwloc', required : false)
@@ -281,7 +286,7 @@ subdir('src/zd11')
 # Libraries
 if build_single
   gen_single = generator(fc_compiler,
-                         output : 'single_@PLAINNAME@',
+                         output : 'single_@BASENAME@.f90',
                          arguments : pp_options + ['-DGALAHAD_SINGLE', '-DSPRAL_SINGLE',
                                      '-I', '@CURRENT_SOURCE_DIR@/include',
                                      '-I', '@CURRENT_SOURCE_DIR@/src/dum/include',
@@ -306,7 +311,7 @@ endif
 
 if build_double
   gen_double = generator(fc_compiler,
-                         output : 'double_@PLAINNAME@',
+                         output : 'double_@BASENAME@.f90',
                          arguments : pp_options + ['-DGALAHAD_DOUBLE', '-DSPRAL_DOUBLE',
                                      '-I', '@CURRENT_SOURCE_DIR@/include',
                                      '-I', '@CURRENT_SOURCE_DIR@/src/dum/include',

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,7 @@ libgalahad_deps = [libblas, liblapack, libmetis, libhsl, libcutest,
 libgalahad_single_src = []
 libgalahad_double_src = []
 libgalahad_integer_src = []
+libgalahad_multi_src = []
 libgalahad_src = []
 libgalahad_aux = []
 
@@ -294,7 +295,7 @@ if build_single
 
   pp_sources_single = gen_single.process([libgalahad_src, libgalahad_c_src, libgalahad_cutest_src, libgalahad_ampl_src])
 
-  sources_single = [libgalahad_single_src, libgalahad_integer_src,
+  sources_single = [libgalahad_multi_src, libgalahad_single_src, libgalahad_integer_src,
                     libgalahad_c_single_src, libgalahad_c_integer_src,
                     pp_sources_single, libgalahad_cpp_src, libgalahad_aux]
 
@@ -319,7 +320,7 @@ if build_double
 
   pp_sources_double = gen_double.process([libgalahad_src, libgalahad_c_src, libgalahad_cutest_src, libgalahad_ampl_src])
 
-  sources_double = [libgalahad_double_src, libgalahad_integer_src,
+  sources_double = [libgalahad_multi_src, libgalahad_double_src, libgalahad_integer_src,
                     libgalahad_c_double_src, libgalahad_c_integer_src,
                     pp_sources_double, libgalahad_cpp_src, libgalahad_aux]
 

--- a/src/lapack/meson.build
+++ b/src/lapack/meson.build
@@ -1,16 +1,16 @@
-libgalahad_src += files('blas_interface.F90', 'lapack_interface.F90')
+libgalahad_multi_src += files('blas_interface.F90', 'lapack_interface.F90')
 
 if not libblas.found()
   warning('building our own BLAS; consider providing an optimized BLAS library')
-  libgalahad_src += files('blas.f')
+  libgalahad_multi_src += files('blas.f')
 endif
 
 if not liblapack.found()
   warning('building our own LAPACK; consider providing an optimized LAPACK library')
-  libgalahad_src += files('lapack.f')
+  libgalahad_multi_src += files('lapack.f')
   if fc.get_id() == 'nagfor'
-    libgalahad_src += files('noieeeck.f')
+    libgalahad_multi_src += files('noieeeck.f')
   else
-    libgalahad_src += files('ieeeck.f')
+    libgalahad_multi_src += files('ieeeck.f')
   endif
 endif


### PR DESCRIPTION
@nimgould 
I updated the main `meson.build` such that the preprocessed files have the extension `.f90` and I don't use anymore the `-cpp` / `-fpp` flag when I compile them.
It fixed the errors with `nagfor` and removed the warnings "bad # preprocessor line" with `ifort`.

However, I have this new error with the NAG compiler:
```shell
FAILED: libgalahad_single.so.p/meson-generated_single_contrib.f90.o 

libgalahad_single.so.p/spral_ssids_contrib_single.mod 
nagfor -Ilibgalahad_single.so.p -I. -I.. -Iinclude -I../include -I../src/dum/include -Isrc/ampl -I../src/ampl -quiet -w=all -O0 -g -dcfuns -Dmetis_nodend=galahad_metis -PIC -DSPRAL_NO_SCHED_GETCPU -DSPRAL_HAVE_HWLOC -DGALAHAD_SINGLE -DSPRAL_SINGLE -mdir libgalahad_single.so.p -o libgalahad_single.so.p/meson-generated_single_contrib.f90.o -c libgalahad_single.so.p/single_contrib.f90
../src/ssids/contrib.F90: In function ‘spral_ssids_contrib_get_data_single’:
../src/ssids/contrib.F90:60:66: error: lvalue required as left operand of assignment
   60 |      call c_f_pointer(ccontrib, fcontrib)
      |  
```

I also observed that I need to compile the C++ files of `ssids` with `-qopenmp` when I use the `icpc` compiler but I have a bunch of errors of the form:
```shell
../src/ssids/ldlt_app.cxx(1944): warning #3850: cancellation point with no cancel in region
                     #pragma omp cancellation point taskgroup
                     ^
          detected during:
            instantiation of "int spral::ssids::cpu::ldlt_app_internal_sgl::LDLT<T, BLOCK_SIZE, Backup, use_tasks, debug, Allocator>::run_elim_unpivoted(int, int, int *, T *, int, T *, spral::ssids::cpu::ldlt_app_internal_sgl::ColumnData<T, spral::ssids::cpu::ldlt_app_internal_sgl::LDLT<T, BLOCK_SIZE, Backup, use_tasks, debug, Allocator>::IntAlloc> &, Backup &, int *, const spral::ssids::cpu::cpu_factor_options &, int, T, T *, int, std::vector<spral::ssids::cpu::Workspace,
                      std::allocator<spral::ssids::cpu::Workspace>> &, const Allocator &) [with T=float, BLOCK_SIZE=32, Backup=spral::ssids::cpu::ldlt_app_internal_sgl::CopyBackup<float, spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>>, use_tasks=false, debug=false, Allocator=spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>]" at line 2350
            instantiation of "int spral::ssids::cpu::ldlt_app_internal_sgl::LDLT<T, BLOCK_SIZE, Backup, use_tasks, debug, Allocator>::factor(int, int, int *, T *, int, T *, Backup &, const spral::ssids::cpu::cpu_factor_options &, spral::ssids::cpu::PivotMethod, int, T, T *, int, std::vector<spral::ssids::cpu::Workspace, std::allocator<spral::ssids::cpu::Workspace>> &, const Allocator &) [with T=float, BLOCK_SIZE=32, Backup=spral::ssids::cpu::ldlt_app_internal_sgl::CopyBackup<float,
                      spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>>, use_tasks=false, debug=false, Allocator=spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>]" at line 999
            instantiation of "int spral::ssids::cpu::ldlt_app_internal_sgl::Block<T, INNER_BLOCK_SIZE, IntAlloc>::factor(int, int *, T *, const spral::ssids::cpu::cpu_factor_options &, std::vector<spral::ssids::cpu::Workspace, std::allocator<spral::ssids::cpu::Workspace>> &, const Allocator &) [with T=float, INNER_BLOCK_SIZE=32, IntAlloc=std::__alloc_rebind<spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>, int>, Allocator=spral::ssids::cpu::BuddyAllocator<float,
                      std::allocator<float>>]" at line 1812
            instantiation of "int spral::ssids::cpu::ldlt_app_internal_sgl::LDLT<T, BLOCK_SIZE, Backup, use_tasks, debug, Allocator>::run_elim_unpivoted(int, int, int *, T *, int, T *, spral::ssids::cpu::ldlt_app_internal_sgl::ColumnData<T, spral::ssids::cpu::ldlt_app_internal_sgl::LDLT<T, BLOCK_SIZE, Backup, use_tasks, debug, Allocator>::IntAlloc> &, Backup &, int *, const spral::ssids::cpu::cpu_factor_options &, int, T, T *, int, std::vector<spral::ssids::cpu::Workspace,
                      std::allocator<spral::ssids::cpu::Workspace>> &, const Allocator &) [with T=float, BLOCK_SIZE=32, Backup=spral::ssids::cpu::ldlt_app_internal_sgl::CopyBackup<float, spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>>, use_tasks=true, debug=false, Allocator=spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>]" at line 2350
            instantiation of "int spral::ssids::cpu::ldlt_app_internal_sgl::LDLT<T, BLOCK_SIZE, Backup, use_tasks, debug, Allocator>::factor(int, int, int *, T *, int, T *, Backup &, const spral::ssids::cpu::cpu_factor_options &, spral::ssids::cpu::PivotMethod, int, T, T *, int, std::vector<spral::ssids::cpu::Workspace, std::allocator<spral::ssids::cpu::Workspace>> &, const Allocator &) [with T=float, BLOCK_SIZE=32, Backup=spral::ssids::cpu::ldlt_app_internal_sgl::CopyBackup<float,
                      spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>>, use_tasks=true, debug=false, Allocator=spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>]" at line 2563
            instantiation of "int spral::ssids::cpu::ldlt_app_factor_sgl(int, int, int *, T *, int, T *, T, T *, int, const spral::ssids::cpu::cpu_factor_options &, std::vector<spral::ssids::cpu::Workspace, std::allocator<spral::ssids::cpu::Workspace>> &, const Allocator &) [with T=float, Allocator=spral::ssids::cpu::BuddyAllocator<float, std::allocator<float>>]" at line 2571
```
It works if we can compile without `-qopenmp` like we currently do in our CI builds but the code is sequential.