### PR TITLE
Use OpenBLAS as the default library for BLAS and LAPACK routines

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,9 +16,9 @@ task:
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
-      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dlibblas= -Dliblapack=
+      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad
     else
-      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad -Dlibblas= -Dliblapack=
+      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad
     fi
   build_script: |
     meson compile -C builddir

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dlibblas= -Dliblapack=
+          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -40,12 +40,12 @@ option('ssids',
 
 option('libblas',
        type : 'string',
-       value : 'blas',
+       value : 'openblas',
        description : 'option for BLAS library switching')
 
 option('liblapack',
        type : 'string',
-       value : 'lapack',
+       value : 'openblas',
        description : 'option for BLAS library switching')
 
 option('libmetis',


### PR DESCRIPTION
@nimgould 
I updated the default value for BLAS and LAPACK libraries.
It's `libopenblas.${dlext}` by default now.
If it's not found, we compile our own version.
  
I don't want that we link with the `libblas.dylib` and `liblapack.dylib` provided by Apple.
