### PR TITLE
[Meson] Add Python interfaces

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,9 +21,9 @@ task:
     echo "OMP_PROC_BIND=TRUE" >> $CIRRUS_ENV
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
-      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dpythoniface=true
+      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir -Dpythoniface=true
     else
-      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad -Dpythoniface=true
+      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir -Dpythoniface=true
     fi
   build_script: |
     meson compile -C builddir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   matrix:
     - name: FreeBSD
       freebsd_instance:
-        image: freebsd-13-1-release-amd64
+        image: freebsd-13-2-release-amd64
     - name: MacOS M1
       macos_instance:
         image: ghcr.io/cirruslabs/macos-monterey-base:latest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,9 +9,11 @@ task:
   dependencies_script: |
     echo $(uname)
     if [ "$(uname)" = "FreeBSD" ]; then
-      pkg install -y meson bash gcc12
+      pkg install -y py39-pip meson bash gcc12
+      pip install numpy
     else
-      brew install meson gcc
+      brew install python meson gcc
+      pip3 install numpy
     fi
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
     echo "OMP_CANCELLATION=TRUE" >> $CIRRUS_ENV
@@ -19,9 +21,9 @@ task:
     echo "OMP_PROC_BIND=TRUE" >> $CIRRUS_ENV
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
-      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad
+      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --prefix=~/galahad -Dpythoniface=true
     else
-      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad
+      FC=gfortran-12 CC=gcc-12 CXX=g++-12 meson setup builddir --prefix=~/galahad -Dpythoniface=true
     fi
   build_script: |
     meson compile -C builddir

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Meson and Ninja
-        run: pip install meson ninja
+        run: pip install meson ninja numpy
 
       - name: Set the environment variable GALAHAD
         shell: bash
@@ -82,7 +82,7 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad
+          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -11,20 +11,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        compiler_version: [10, 11, 12]
+        # os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
+        # compiler_version: [10, 11, 12]
+        compiler_version: [11]
         include:
           - compiler: gnu
             cc_cmd: gcc
             fc_cmd: gfortran
             cxx_cmd: g++
-          - os: ubuntu-latest
-            compiler: intel-llvm
-            compiler_version: 2023.2
-            cc_cmd: icx
-            fc_cmd: ifort
-            cxx_cmd: icpx
-            allow_failure: true
+          # - os: ubuntu-latest
+          #   compiler: intel-llvm
+          #   compiler_version: 2023.2
+          #   cc_cmd: icx
+          #   fc_cmd: ifort
+          #   cxx_cmd: icpx
+          #   allow_failure: true
           # - os: ubuntu-latest
           #   compiler: intel-llvm
           #   compiler_version: 2023.2
@@ -82,16 +84,16 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true
+          meson setup builddir -Dpythoniface=true
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}
           CXX: ${{ matrix.cxx_cmd }}
 
       # Uncomment this section to obtain ssh access to VM
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
-      #
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
 
       - name: Build GALAHAD
         shell: bash

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true -Dexamples=false -Dsingle=false
+          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}
@@ -120,7 +120,7 @@ jobs:
       - name: Test GALAHAD
         shell: bash
         run: |
-          meson test -C builddir --suite=Python
+          meson test -C builddir
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -11,22 +11,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [windows-latest, ubuntu-latest, macos-latest]
-        os: [ubuntu-latest]
-        # compiler_version: [10, 11, 12]
-        compiler_version: [11]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        compiler_version: [12]
         include:
           - compiler: gnu
             cc_cmd: gcc
             fc_cmd: gfortran
             cxx_cmd: g++
-          # - os: ubuntu-latest
-          #   compiler: intel-llvm
-          #   compiler_version: 2023.2
-          #   cc_cmd: icx
-          #   fc_cmd: ifort
-          #   cxx_cmd: icpx
-          #   allow_failure: true
+          - os: ubuntu-latest
+            compiler: intel-llvm
+            compiler_version: 2023.2
+            cc_cmd: icx
+            fc_cmd: ifort
+            cxx_cmd: icpx
+            allow_failure: true
           # - os: ubuntu-latest
           #   compiler: intel-llvm
           #   compiler_version: 2023.2
@@ -49,8 +47,12 @@ jobs:
 
       - name: Set the environment variable GALAHAD
         shell: bash
-        run: |
-          echo "GALAHAD=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        run: echo "GALAHAD=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Set the environment variable LD_LIBRARY_PATH
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib" >> $GITHUB_ENV
 
       - name: Set environment variables for OpenMP
         if: matrix.os != 'windows-latest'
@@ -84,16 +86,11 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir -Dpythoniface=true
+          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true -Dexamples=false -Dsingle=false
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}
           CXX: ${{ matrix.cxx_cmd }}
-
-      # Uncomment this section to obtain ssh access to VM
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
 
       - name: Build GALAHAD
         shell: bash
@@ -115,10 +112,15 @@ jobs:
           name: ${{ matrix.os }}_${{ matrix.fc_cmd }}_${{ matrix.compiler_version }}_install-log.txt
           path: builddir/meson-logs/install-log.txt
 
+      # Uncomment this section to obtain ssh access to VM
+      # - name: Setup tmate session
+      #   if: matrix.os == 'windows-latest'
+      #   uses: mxschmitt/action-tmate@v3
+
       - name: Test GALAHAD
         shell: bash
         run: |
-          meson test -C builddir
+          meson test -C builddir --suite=Python
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/README.meson
+++ b/README.meson
@@ -107,6 +107,7 @@ Currently supported suites:
 * `package`;
 * `fortran`;
 * `C`;
+* `Python`;
 * `single`;
 * `double`.
 

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c', 'cpp', 'fortran',
   version: '5.0.0',
   license: 'BSD-3',
-  meson_version: '>= 0.61.0',
+  meson_version: '>= 0.63.0',
   default_options: [
     'buildtype=debug',
     'libdir=lib',
@@ -19,6 +19,7 @@ cxx = meson.get_compiler('cpp')
 fc = meson.get_compiler('fortran')
 fc_compiler = find_program(fc.cmd_array())
 fs = import('fs')
+py = import('python').find_installation()
 
 # Remove messages about deprecated Intel compilers
 if cc.get_id() == 'intel' or cc.get_id() == 'intel-cl'
@@ -149,11 +150,13 @@ libgalahad_c_src = []
 libgalahad_cpp_src = []
 libgalahad_cutest_src = []
 libgalahad_ampl_src = []
+libgalahad_python_src = []
 
 galahad_examples = []
 galahad_c_examples = []
 galahad_tests = []
 galahad_c_tests = []
+galahad_python_tests = []
 
 # Headers and Fortran modules
 libgalahad_include = [include_directories('include'),
@@ -337,6 +340,41 @@ if build_double
                               install : true)
 endif
 
+if build_pythoniface and build_ciface and build_double
+  incdir_numpy = run_command(py,
+    ['-c', 'import numpy; print(numpy.get_include())'],
+    check : true
+  ).stdout().strip()
+  libgalahad_include += [incdir_numpy]
+
+  py_src = []
+  foreach interface: libgalahad_python_src
+    file = interface[1]
+    py_src += file
+  endforeach
+
+  py.extension_module('galahad',
+                      sources : py_src,
+                      link_with : libgalahad_double,
+                      link_language : 'c',
+                      include_directories : libgalahad_include,
+                      subdir : 'galahad',
+                      install : true)
+
+  # foreach interface: libgalahad_python_src
+  #   name = interface[0]
+  #   file = interface[1]
+
+  #   py.extension_module(name,
+  #                       sources : file,
+  #                       link_with : libgalahad_double,
+  #                       link_language : 'c',
+  #                       include_directories : libgalahad_include,
+  #                       subdir : 'galahad',
+  #                       install : true)
+  # endforeach
+endif
+
 # Binaries
 foreach binary: galahad_binaries
   binname = binary[0]
@@ -394,6 +432,15 @@ if build_tests
       package = test[0]
       name = test[1] + '_' + precision
       file = test[2]
+
+      deps_tests = libgalahad_deps
+      if precision == 'single'
+        deps_tests += libgalahad_single_deps
+      endif
+      if precision == 'double'
+        deps_tests += libgalahad_double_deps
+      endif
+
       if not (name == 'croti_single')
         test(name,
              executable(name, file, fortran_args : args_precision, link_with : libgalahad_precision, dependencies : libgalahad_deps + libgalahad_single_deps + libgalahad_double_deps,
@@ -425,6 +472,24 @@ if build_tests and build_ciface
            suite : [package, precision, 'C'],
            is_parallel : false)
     endforeach
+  endforeach
+endif
+
+# Python tests
+if build_tests and build_pythoniface and build_ciface and build_double
+
+  pypathdir = meson.current_build_dir()
+
+  foreach test: galahad_python_tests
+    package = test[0]
+    name = test[1]
+    file = test[2]
+    test(name,
+         py,
+         args : file,
+         suite : [package, 'Python'],
+         env : ['PYTHONPATH=' + pypathdir],
+         is_parallel : false)
   endforeach
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -347,32 +347,18 @@ if build_pythoniface and build_ciface and build_double
   ).stdout().strip()
   libgalahad_include += [incdir_numpy]
 
-  py_src = []
   foreach interface: libgalahad_python_src
+    name = interface[0]
     file = interface[1]
-    py_src += file
+
+    py.extension_module(name,
+                        sources : file,
+                        link_with : libgalahad_double,
+                        link_language : 'c',
+                        include_directories : libgalahad_include,
+                        subdir : 'galahad',
+                        install : true)
   endforeach
-
-  py.extension_module('galahad',
-                      sources : py_src,
-                      link_with : libgalahad_double,
-                      link_language : 'c',
-                      include_directories : libgalahad_include,
-                      subdir : 'galahad',
-                      install : true)
-
-  # foreach interface: libgalahad_python_src
-  #   name = interface[0]
-  #   file = interface[1]
-
-  #   py.extension_module(name,
-  #                       sources : file,
-  #                       link_with : libgalahad_double,
-  #                       link_language : 'c',
-  #                       include_directories : libgalahad_include,
-  #                       subdir : 'galahad',
-  #                       install : true)
-  # endforeach
 endif
 
 # Binaries
@@ -478,8 +464,6 @@ endif
 # Python tests
 if build_tests and build_pythoniface and build_ciface and build_double
 
-  pypathdir = meson.current_build_dir()
-
   foreach test: galahad_python_tests
     package = test[0]
     name = test[1]
@@ -488,7 +472,7 @@ if build_tests and build_pythoniface and build_ciface and build_double
          py,
          args : file,
          suite : [package, 'Python'],
-         env : ['PYTHONPATH=' + pypathdir],
+         env : ['PYTHONPATH=' + py.get_install_dir()],
          is_parallel : false)
   endforeach
 endif

--- a/meson.build
+++ b/meson.build
@@ -340,6 +340,7 @@ if build_double
                               install : true)
 endif
 
+# Python interface
 if build_pythoniface and build_ciface and build_double
   incdir_numpy = run_command(py,
     ['-c', 'import numpy; print(numpy.get_include())'],
@@ -347,6 +348,10 @@ if build_pythoniface and build_ciface and build_double
   ).stdout().strip()
   libgalahad_include += [incdir_numpy]
 
+  # install python metadata
+  install_data(files('doc/PYTHON_METADATA'), install_dir : join_paths(py.get_install_dir(),'galahad-'+meson.project_version()+'.dist-info'))
+
+  # compile and install python interfaces
   foreach interface: libgalahad_python_src
     name = interface[0]
     file = interface[1]

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ fc = meson.get_compiler('fortran')
 fc_compiler = find_program(fc.cmd_array())
 fs = import('fs')
 py = import('python').find_installation()
+host_system = host_machine.system()
 
 # Remove messages about deprecated Intel compilers
 if cc.get_id() == 'intel' or cc.get_id() == 'intel-cl'
@@ -467,7 +468,7 @@ if build_tests and build_ciface
 endif
 
 # Python tests
-if build_tests and build_pythoniface and build_ciface and build_double
+if build_tests and build_pythoniface and build_ciface and build_double and host_system != 'windows'
 
   foreach test: galahad_python_tests
     package = test[0]

--- a/src/arc/meson.build
+++ b/src/arc/meson.build
@@ -5,7 +5,11 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['arc', files('Python/arc_pyiface.c')]]
+  libgalahad_python_src += [['arc', files('Python/arc_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../rqs/Python/rqs_pyiface.c',
+                                          '../glrt/Python/glrt_pyiface.c','../psls/Python/psls_pyiface.c','../dps/Python/dps_pyiface.c',
+                                          '../lms/Python/lms_pyiface.c','../sha/Python/sha_pyiface.c','../sils/Python/sils_pyiface.c',
+                                          '../rpd/Python/rpd_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/arc/meson.build
+++ b/src/arc/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('arc.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/arc_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['arc', files('Python/arc_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usearc.F90', 'runarc_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['arc', 'arct', files('arct.F90')],
 
 galahad_c_tests += [['arc', 'arct_c', files('C/arct.c')],
                     ['arc', 'arctf_c', files('C/arctf.c')]]
+
+galahad_python_tests += [['arc', 'arc_py', files('Python/test_arc.py')]]
 
 galahad_examples += [['arcs', files('arcs.f90')],
                      ['arcs2', files('arcs2.f90')],

--- a/src/bgo/Python/test_bgo_quadratic.py
+++ b/src/bgo/Python/test_bgo_quadratic.py
@@ -5,7 +5,7 @@ import numpy as np
 bgo.initialize()
 
 # set some non-default options
-options = {'print_level' : 3, 'ugo_options' : {'print_level' : 4}}
+options = {'print_level' : 1, 'ugo_options' : {'print_level' : 0}}
 print(options)
 
 # set bounds
@@ -30,15 +30,13 @@ def eval_f(x):
 def eval_g(x):
     return np.array([2*x[0],2*x[1]])
 def eval_h(x):
-    return np.array([2,2])
-def eval_hprod(x,u,v):
-    return np.array([u[0]+2*v[0],u[1]+2*v[1]])
+    return np.array([2.,2.])
 
 # starting value
 x = np.array([2.,2.])
 
 # find optimum
-x, g = bgo.solve(n, H_ne, x, eval_f, eval_g, eval_h, eval_hprod)
+x, g = bgo.solve(n, H_ne, x, eval_f, eval_g, eval_h)
 print("x:",x)
 print("g:",g)
 

--- a/src/bgo/meson.build
+++ b/src/bgo/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('bgo.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/bgo_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['bgo', files('Python/bgo_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usebgo.F90', 'runbgo_sif.F90')
 endif
@@ -11,6 +17,9 @@ galahad_tests += [['bgo', 'bgot', files('bgot.F90')],
 
 galahad_c_tests += [['bgo', 'bgot_c', files('C/bgot.c')],
                     ['bgo', 'bgotf_c', files('C/bgotf.c')]]
+
+galahad_python_tests += [['bgo', 'bgo_py', files('Python/test_bgo.py')],
+                         ['bgo', 'bgo_quadratic_py', files('Python/test_bgo_quadratic.py')]]
 
 galahad_examples += [['bgos', files('bgos.f90')],
                      ['bgos2', files('bgos2.f90')]]

--- a/src/bgo/meson.build
+++ b/src/bgo/meson.build
@@ -5,7 +5,11 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['bgo', files('Python/bgo_pyiface.c')]]
+  libgalahad_python_src += [['bgo', files('Python/bgo_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../trs/Python/trs_pyiface.c',
+                                          '../gltr/Python/gltr_pyiface.c','../lhs/Python/lhs_pyiface.c','../lms/Python/lms_pyiface.c',
+                                          '../psls/Python/psls_pyiface.c','../sha/Python/sha_pyiface.c','../trb/Python/trb_pyiface.c',
+                                          '../ugo/Python/ugo_pyiface.c','../sils/Python/sils_pyiface.c','../rpd/Python/rpd_pyiface.c')]]                                  
 endif
 
 if libcutest.found()

--- a/src/blls/meson.build
+++ b/src/blls/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['blls', files('Python/blls_pyiface.c')]]
+  libgalahad_python_src += [['blls', files('Python/blls_pyiface.c',
+                                           '../sbls/Python/sbls_pyiface.c','../convert/Python/convert_pyiface.c','../sls/Python/sls_pyiface.c',
+                                           '../uls/Python/uls_pyiface.c','../roots/Python/roots_pyiface.c','../sils/Python/sils_pyiface.c',
+                                           '../gls/Python/gls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/blls/meson.build
+++ b/src/blls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('blls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/blls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['blls', files('Python/blls_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useblls.F90', 'runblls_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['blls', 'bllst', files('bllst.F90')],
 
 galahad_c_tests += [['blls', 'bllst_c', files('C/bllst.c')],
                     ['blls', 'bllstf_c', files('C/bllstf.c')]]
+
+galahad_python_tests += [['blls', 'blls_py', files('Python/test_blls.py')]]
 
 galahad_examples += [['bllss', files('bllss.f90')],
                      ['bllss2', files('bllss2.f90')],

--- a/src/bqp/meson.build
+++ b/src/bqp/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('bqp.F90')
+
 galahad_binaries += [['inbqp', files('inbqp.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/bqp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['bqp', files('Python/bqp_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usebqp.F90', 'runbqp_sif.F90')
 endif
@@ -12,6 +19,8 @@ galahad_tests += [['bqp', 'bqpt', files('bqpt.F90')],
 
 galahad_c_tests += [['bqp', 'bqpt_c', files('C/bqpt.c')],
                     ['bqp', 'bqptf_c', files('C/bqptf.c')]]
+
+galahad_python_tests += [['bqp', 'bqp_py', files('Python/test_bqp.py')]]
 
 galahad_examples += [['bqps', files('bqps.f90')],
                      ['bqps2', files('bqps2.f90')],

--- a/src/bqp/meson.build
+++ b/src/bqp/meson.build
@@ -7,7 +7,9 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['bqp', files('Python/bqp_pyiface.c')]]
+  libgalahad_python_src += [['bqp', files('Python/bqp_pyiface.c',
+                                          '../sbls/Python/sbls_pyiface.c','../gltr/Python/gltr_pyiface.c','../sls/Python/sls_pyiface.c',
+                                          '../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c','../gls/Python/gls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/bqpb/meson.build
+++ b/src/bqpb/meson.build
@@ -7,7 +7,12 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['bqpb', files('Python/bqpb_pyiface.c')]]
+  libgalahad_python_src += [['bqpb', files('Python/bqpb_pyiface.c',
+                                           '../sbls/Python/sbls_pyiface.c','../sls/Python/sls_pyiface.c','../uls/Python/uls_pyiface.c',
+                                           '../roots/Python/roots_pyiface.c','../sils/Python/sils_pyiface.c','../gls/Python/gls_pyiface.c',
+                                           '../scu/Python/scu_pyiface.c','../fit/Python/fit_pyiface.c','../ir/Python/ir_pyiface.c',
+                                           '../cro/Python/cro_pyiface.c','../lms/Python/lms_pyiface.c','../rpd/Python/rpd_pyiface.c',
+                                           '../fdc/Python/fdc_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/bqpb/meson.build
+++ b/src/bqpb/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('bqpb.F90')
+
 galahad_binaries += [['inbqpb', files('inbqpb.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/bqpb_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['bqpb', files('Python/bqpb_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usebqpb.F90', 'runbqpb_sif.F90')
 endif
@@ -12,6 +19,8 @@ galahad_tests += [['bqpb', 'bqpbt', files('bqpbt.F90')],
 
 galahad_c_tests += [['bqpb', 'bqpbt_c', files('C/bqpbt.c')],
                     ['bqpb', 'bqpbtf_c', files('C/bqpbtf.c')]]
+
+galahad_python_tests += [['bqpb', 'bqpb_py', files('Python/test_bqpb.py')]]
 
 galahad_examples += [['bqpbs', files('bqpbs.f90')],
                      ['bqpbs2', files('bqpbs2.f90')]]

--- a/src/bsc/meson.build
+++ b/src/bsc/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('bsc.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/bsc_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['bsc', files('Python/bsc_pyiface.c')]]
+endif
+
 galahad_tests += [['bsc', 'bsct', files('bsct.F90')]]
+
+galahad_python_tests += [['bsc', 'bsc_py', files('Python/test_bsc.py')]]
 
 galahad_examples += [['bscs', files('bscs.f90')]]

--- a/src/convert/meson.build
+++ b/src/convert/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('convert.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/convert_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['convert', files('Python/convert_pyiface.c')]]
+endif
+
 galahad_tests += [['convert', 'convertt', files('convertt.F90')]]
+
+galahad_python_tests += [['convert', 'convert_py', files('Python/test_convert.py')]]
 
 galahad_examples += [['converts', files('converts.f90')]]

--- a/src/cqp/meson.build
+++ b/src/cqp/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('cqp.F90')
+
 galahad_binaries += [['incqp', files('incqp.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/cqp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['cqp', files('Python/cqp_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usecqp.F90', 'runcqp_sif.F90')
 endif
@@ -12,6 +19,8 @@ galahad_tests += [['cqp', 'cqpt', files('cqpt.F90')],
 
 galahad_c_tests += [['cqp', 'cqpt_c', files('C/cqpt.c')],
                     ['cqp', 'cqptf_c', files('C/cqptf.c')]]
+
+galahad_python_tests += [['cqp', 'cqp_py', files('Python/test_cqp.py')]]
 
 galahad_examples += [['cqps', files('cqps.f90')],
                      ['cqps2', files('cqps2.f90')],

--- a/src/cqp/meson.build
+++ b/src/cqp/meson.build
@@ -7,7 +7,12 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['cqp', files('Python/cqp_pyiface.c')]]
+  libgalahad_python_src += [['cqp', files('Python/cqp_pyiface.c',
+                                          '../sbls/Python/sbls_pyiface.c','../sls/Python/sls_pyiface.c','../uls/Python/uls_pyiface.c',
+                                          '../roots/Python/roots_pyiface.c','../sils/Python/sils_pyiface.c','../gls/Python/gls_pyiface.c',
+                                          '../fdc/Python/fdc_pyiface.c','../scu/Python/scu_pyiface.c','../fit/Python/fit_pyiface.c',
+                                          '../ir/Python/ir_pyiface.c','../cro/Python/cro_pyiface.c','../rpd/Python/rpd_pyiface.c',
+                                          '../lms/Python/lms_pyiface.c',)]]
 endif
 
 if libcutest.found()

--- a/src/cro/meson.build
+++ b/src/cro/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['cro', files('Python/cro_pyiface.c')]]
+  libgalahad_python_src += [['cro', files('Python/cro_pyiface.c',
+                                          '../sbls/Python/sbls_pyiface.c','../lms/Python/lms_pyiface.c','../scu/Python/scu_pyiface.c',
+                                          '../ir/Python/ir_pyiface.c','../rpd/Python/rpd_pyiface.c','../sls/Python/sls_pyiface.c',
+                                          '../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c','../gls/Python/gls_pyiface.c')]]
 endif
 
 galahad_tests += [['cro', 'crot', files('crot.F90')],

--- a/src/cro/meson.build
+++ b/src/cro/meson.build
@@ -4,11 +4,17 @@ if build_ciface
   libgalahad_c_src += files('C/cro_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['cro', files('Python/cro_pyiface.c')]]
+endif
+
 galahad_tests += [['cro', 'crot', files('crot.F90')],
                   ['cro', 'croti', files('croti.F90')]]
 
 galahad_c_tests += [['cro', 'crot_c', files('C/crot.c')],
                     ['cro', 'crotf_c', files('C/crotf.c')]]
+
+galahad_python_tests += [['cro', 'cro_py', files('Python/test_cro.py')]]
 
 galahad_examples += [['cros', files('cros.f90')],
                      ['cros2', files('cros2.f90')],

--- a/src/dgo/Python/test_dgo_quadratic.py
+++ b/src/dgo/Python/test_dgo_quadratic.py
@@ -5,7 +5,7 @@ import numpy as np
 dgo.initialize()
 
 # set some non-default options
-options = {'print_level' : 3, 'ugo_options' : {'print_level' : 4}}
+options = {'print_level' : 1, 'ugo_options' : {'print_level' : 0}}
 print(options)
 
 # set bounds
@@ -30,7 +30,7 @@ def eval_f(x):
 def eval_g(x):
     return np.array([2*x[0],2*x[1]])
 def eval_h(x):
-    return np.array([2,2])
+    return np.array([2.,2.])
 def eval_hprod(x,u,v):
     return np.array([u[0]+2*v[0],u[1]+2*v[1]])
 
@@ -38,7 +38,7 @@ def eval_hprod(x,u,v):
 x = np.array([2.,2.])
 
 # find optimum
-x, g = dgo.solve(n, H_ne, x, eval_f, eval_g, eval_h, eval_hprod)
+x, g = dgo.solve(n, H_ne, x, eval_f, eval_g, eval_h)
 print("x:",x)
 print("g:",g)
 

--- a/src/dgo/meson.build
+++ b/src/dgo/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('dgo.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/dgo_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['dgo', files('Python/dgo_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usedgo.F90', 'rundgo_sif.F90')
 endif
@@ -11,6 +17,9 @@ galahad_tests += [['dgo', 'dgot', files('dgot.F90')],
 
 galahad_c_tests += [['dgo', 'dgot_c', files('C/dgot.c')],
                     ['dgo', 'dgotf_c', files('C/dgotf.c')]]
+
+galahad_python_tests += [['dgo', 'dgo_py', files('Python/test_dgo.py')],
+                         ['dgo', 'dgo_quadratic_py', files('Python/test_dgo_quadratic.py')]]
 
 galahad_examples += [['dgos', files('dgos.f90')],
                      ['dgos2', files('dgos2.f90')]]

--- a/src/dgo/meson.build
+++ b/src/dgo/meson.build
@@ -5,7 +5,11 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['dgo', files('Python/dgo_pyiface.c')]]
+  libgalahad_python_src += [['dgo', files('Python/dgo_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../trs/Python/trs_pyiface.c',
+                                          '../gltr/Python/gltr_pyiface.c','../lhs/Python/lhs_pyiface.c','../lms/Python/lms_pyiface.c',
+                                          '../psls/Python/psls_pyiface.c','../sha/Python/sha_pyiface.c','../trb/Python/trb_pyiface.c',
+                                          '../ugo/Python/ugo_pyiface.c','../hash/Python/hash_pyiface.c','../sils/Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/dps/meson.build
+++ b/src/dps/meson.build
@@ -5,7 +5,8 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['dps', files('Python/dps_pyiface.c')]]
+  libgalahad_python_src += [['dps', files('Python/dps_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../sils/Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/dps/meson.build
+++ b/src/dps/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('dps.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/dps_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['dps', files('Python/dps_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usedps.F90', 'rundps_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['dps', 'dpst', files('dpst.F90')]]
 
 galahad_c_tests += [['dps', 'dpst_c', files('C/dpst.c')],
                     ['dps', 'dpstf_c', files('C/dpstf.c')]]
+
+galahad_python_tests += [['dps', 'dps_py', files('Python/test_dps.py')]]
 
 galahad_examples += [['dpss', files('dpss.f90')],
                      ['dpss2', files('dpss2.f90')]]

--- a/src/dqp/meson.build
+++ b/src/dqp/meson.build
@@ -7,7 +7,11 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['dqp', files('Python/dqp_pyiface.c')]]
+  libgalahad_python_src += [['dqp', files('Python/dqp_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../sbls/Python/sbls_pyiface.c','../gltr/Python/gltr_pyiface.c',
+                                          '../scu/Python/scu_pyiface.c','../rpd/Python/rpd_pyiface.c','../sils/Python/sils_pyiface.c',
+                                          '../lms/Python/lms_pyiface.c','../fdc/Python/fdc_pyiface.c','../uls/Python/uls_pyiface.c',
+                                          '../gls/Python/gls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/dqp/meson.build
+++ b/src/dqp/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('dqp.F90')
+
 galahad_binaries += [['indqp', files('indqp.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/dqp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['dqp', files('Python/dqp_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usedqp.F90', 'rundqp_sif.F90')
 endif
@@ -13,6 +20,8 @@ galahad_tests += [['dqp', 'dqpt', files('dqpt.F90')],
 galahad_c_tests += [['dqp', 'dqpt_c', files('C/dqpt.c')],
                     ['dqp', 'dqpt2_c', files('C/dqpt2.c')],
                     ['dqp', 'dqptf_c', files('C/dqptf.c')]]
+
+galahad_python_tests += [['dqp', 'dqp_py', files('Python/test_dqp.py')]]
 
 galahad_examples += [['dqps', files('dqps.f90')],
                      ['dqps2', files('dqps2.f90')],

--- a/src/eqp/meson.build
+++ b/src/eqp/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['eqp', files('Python/eqp_pyiface.c')]]
+  libgalahad_python_src += [['eqp', files('Python/eqp_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../sbls/Python/sbls_pyiface.c','../gltr/Python/gltr_pyiface.c',
+                                          '../fdc/Python/fdc_pyiface.c','../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c',
+                                          '../gls/Python/gls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/eqp/meson.build
+++ b/src/eqp/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('eqp.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/eqp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['eqp', files('Python/eqp_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useeqp.F90', 'runeqp_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['eqp', 'eqpt', files('eqpt.F90')],
 
 galahad_c_tests += [['eqp', 'eqpt_c', files('C/eqpt.c')],
                     ['eqp', 'eqptf_c', files('C/eqptf.c')]]
+
+galahad_python_tests += [['eqp', 'eqp_py', files('Python/test_eqp.py')]]
 
 galahad_examples += [['eqps', files('eqps.f90')]]

--- a/src/fdc/meson.build
+++ b/src/fdc/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('fdc.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/fdc_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['fdc', files('Python/fdc_pyiface.c')]]
 endif
 
 galahad_tests += [['fdc', 'fdct', files('fdct.F90')],
@@ -8,5 +13,7 @@ galahad_tests += [['fdc', 'fdct', files('fdct.F90')],
 
 galahad_c_tests += [['fdc', 'fdct_c', files('C/fdct.c')],
                     ['fdc', 'fdctf_c', files('C/fdctf.c')]]
+
+galahad_python_tests += [['fdc', 'fdc_py', files('Python/test_fdc.py')]]
 
 galahad_examples += [['fdcs', files('fdcs.f90')]]

--- a/src/fdc/meson.build
+++ b/src/fdc/meson.build
@@ -5,7 +5,9 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['fdc', files('Python/fdc_pyiface.c')]]
+  libgalahad_python_src += [['fdc', files('Python/fdc_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../uls/Python/uls_pyiface.c','../sils/Python/sils_pyiface.c',
+                                          '../gls/Python/gls_pyiface.c')]]
 endif
 
 galahad_tests += [['fdc', 'fdct', files('fdct.F90')],

--- a/src/fit/meson.build
+++ b/src/fit/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('fit.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/fit_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['fit', files('Python/fit_pyiface.c')]]
+endif
+
 galahad_tests += [['fit', 'fitt', files('fitt.F90')]]
+
+galahad_python_tests += [['fit', 'fit_py', files('Python/test_fit.py')]]
 
 galahad_examples += [['fits', files('fits.f90')]]

--- a/src/glrt/meson.build
+++ b/src/glrt/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('glrt.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/glrt_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['glrt', files('Python/glrt_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useglrt.F90', 'runglrt_sif.F90')
 endif
@@ -9,5 +15,7 @@ endif
 galahad_tests += [['glrt', 'glrtt', files('glrtt.F90')]]
 
 galahad_c_tests += [['glrt', 'glrtt_c', files('C/glrtt.c')]]
+
+galahad_python_tests += [['glrt', 'glrt_py', files('Python/test_glrt.py')]]
 
 galahad_examples += [['glrts', files('glrts.f90')]]

--- a/src/gls/Python/test_gls.py
+++ b/src/gls/Python/test_gls.py
@@ -39,9 +39,8 @@ b = np.array([1.0,3.0,5.0])
 #print("transpose x:",xt)
 
 # get information
-inform = gls.information()
-print("rank:",inform['rank'])
+ainform, finform, sinform = gls.information()
+print("rank:",ainform['rank'])
 
 # deallocate internal data
-
-gls.terminate()
+gls.finalize()

--- a/src/gls/meson.build
+++ b/src/gls/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('gls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/gls_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['gls', files('Python/gls_pyiface.c')]]
+endif
+
 galahad_tests += [['gls', 'glst', files('glst.F90')]]
+
+galahad_python_tests += [['gls', 'gls_py', files('Python/test_gls.py')]]
 
 galahad_examples += [['glss', files('glss.f90')]]

--- a/src/gltr/meson.build
+++ b/src/gltr/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('gltr.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/gltr_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['gltr', files('Python/gltr_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usegltr.F90', 'rungltr_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['gltr', 'gltrt', files('gltrt.F90')],
                   ['gltr', 'gltrti', files('gltrti.F90')]]
 
 galahad_c_tests += [['gltr', 'gltrt_c', files('C/gltrt.c')]]
+
+galahad_python_tests += [['gltr', 'gltr_py', files('Python/test_gltr.py')]]
 
 galahad_examples += [['gltrs', files('gltrs.f90')],
                      ['gltrs2', files('gltrs2.f90')],

--- a/src/hash/meson.build
+++ b/src/hash/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('hash.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/hash_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['hash', files('Python/hash_pyiface.c')]]
+endif
+
 galahad_tests += [['hash', 'hasht', files('hasht.F90')]]
+
+galahad_python_tests += [['hash', 'hash_py', files('Python/test_hash.py')]]
 
 galahad_examples += [['hashs', files('hashs.f90')]]

--- a/src/ir/meson.build
+++ b/src/ir/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('ir.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/ir_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['ir', files('Python/ir_pyiface.c')]]
+endif
+
 galahad_tests += [['ir', 'irt', files('irt.F90')]]
+
+galahad_python_tests += [['ir', 'ir_py', files('Python/test_ir.py')]]
 
 galahad_examples += [['irs', files('irs.f90')]]

--- a/src/l2rt/meson.build
+++ b/src/l2rt/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('l2rt.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/l2rt_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['l2rt', files('Python/l2rt_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usel2rt.F90', 'runl2rt_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['l2rt', 'l2rtt', files('l2rtt.F90')],
                   ['l2rt', 'l2rtti', files('l2rtti.F90')]]
 
 galahad_c_tests += [['l2rt', 'l2rtt_c', files('C/l2rtt.c')]]
+
+galahad_python_tests += [['l2rt', 'l2rt_py', files('Python/test_l2rt.py')]]
 
 galahad_examples += [['l2rts', files('l2rts.f90')],
                      ['l2rts2', files('l2rts2.f90')]]

--- a/src/lhs/meson.build
+++ b/src/lhs/meson.build
@@ -1,11 +1,18 @@
 libgalahad_src += files('lhs.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lhs_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['lhs', files('Python/lhs_pyiface.c')]]
 endif
 
 galahad_tests += [['lhs', 'lhst', files('lhst.F90')]]
 
 galahad_c_tests += [['lhs', 'lhst_c', files('C/lhst.c')]]
+
+galahad_python_tests += [['lhs', 'lhs_py', files('Python/test_lhs.py')]]
 
 galahad_examples += [['lhss', files('lhss.f90')]]
 

--- a/src/llsr/meson.build
+++ b/src/llsr/meson.build
@@ -4,6 +4,10 @@ if build_ciface
   libgalahad_c_src += files('C/llsr_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['llsr', files('Python/llsr_pyiface.c')]]
+endif
+
 galahad_tests += [['llsr', 'llsrt', files('llsrt.F90')],
                   ['llsr', 'llsrti', files('llsrti.F90')]]
 
@@ -13,3 +17,5 @@ galahad_c_tests += [['llsr', 'llsrt_c', files('C/llsrt.c')],
 galahad_examples += [['llsrs', files('llsrs.f90')],
                      ['llsrs2', files('llsrs2.f90')],
                      ['llsrs3', files('llsrs3.f90')]]
+
+galahad_python_tests += [['llsr', 'llsr_py', files('Python/test_llsr.py')]]

--- a/src/llsr/meson.build
+++ b/src/llsr/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['llsr', files('Python/llsr_pyiface.c')]]
+  libgalahad_python_src += [['llsr', files('Python/llsr_pyiface.c',
+                                           '../sbls/Python/sbls_pyiface.c','../sls/Python/sls_pyiface.c','../uls/Python/uls_pyiface.c',
+                                           '../roots/Python/roots_pyiface.c','../sils/Python/sils_pyiface.c','../gls/Python/gls_pyiface.c',
+                                           '../ir/Python/ir_pyiface.c')]]
 endif
 
 galahad_tests += [['llsr', 'llsrt', files('llsrt.F90')],

--- a/src/llst/meson.build
+++ b/src/llst/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['llst', files('Python/llst_pyiface.c')]]
+  libgalahad_python_src += [['llst', files('Python/llst_pyiface.c',
+                                           '../sbls/Python/sbls_pyiface.c','../sls/Python/sls_pyiface.c','../uls/Python/uls_pyiface.c',
+                                           '../roots/Python/roots_pyiface.c','../sils/Python/sils_pyiface.c','../gls/Python/gls_pyiface.c',
+                                           '../ir/Python/ir_pyiface.c')]]
 endif
 
 galahad_tests += [['llst', 'llstt', files('llstt.F90')],

--- a/src/llst/meson.build
+++ b/src/llst/meson.build
@@ -4,11 +4,17 @@ if build_ciface
   libgalahad_c_src += files('C/llst_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['llst', files('Python/llst_pyiface.c')]]
+endif
+
 galahad_tests += [['llst', 'llstt', files('llstt.F90')],
                   ['llst', 'llstti', files('llstti.F90')]]
 
 galahad_c_tests += [['llst', 'llstt_c', files('C/llstt.c')],
                     ['llst', 'llsttf_c', files('C/llsttf.c')]]
+
+galahad_python_tests += [['llst', 'llst_py', files('Python/test_llst.py')]]
 
 galahad_examples += [['llsts', files('llsts.f90')],
                      ['llsts2', files('llsts2.f90')],

--- a/src/lms/meson.build
+++ b/src/lms/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('lms.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lms_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['lms', files('Python/lms_pyiface.c')]]
+endif
+
 galahad_tests += [['lms', 'lmst', files('lmst.F90')]]
+
+galahad_python_tests += [['lms', 'lms_py', files('Python/test_lms.py')]]
 
 galahad_examples += [['lmss', files('lmss.f90')]]

--- a/src/lpa/meson.build
+++ b/src/lpa/meson.build
@@ -7,7 +7,8 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['lpa', files('Python/lpa_pyiface.c')]]
+  libgalahad_python_src += [['lpa', files('Python/lpa_pyiface.c',
+                                          '../rpd/Python/rpd_pyiface.c','../lms/Python/lms_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/lpa/meson.build
+++ b/src/lpa/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('lpa.F90')
+
 galahad_binaries += [['inlpa', files('inlpa.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/lpa_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['lpa', files('Python/lpa_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselpa.F90', 'runlpa_sif.F90')
 endif
@@ -12,5 +19,7 @@ galahad_tests += [['lpa', 'lpat', files('lpat.F90')],
 
 galahad_c_tests += [['lpa', 'lpat_c', files('C/lpat.c')],
                     ['lpa', 'lpatf_c', files('C/lpatf.c')]]
+
+galahad_python_tests += [['lpa', 'lpa_py', files('Python/test_lpa.py')]]
 
 galahad_examples += [['lpas', files('lpas.f90')]]

--- a/src/lpb/meson.build
+++ b/src/lpb/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('lpb.F90')
+
 galahad_binaries += [['inlpb', files('inlpb.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/lpb_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['lpb', files('Python/lpb_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselpb.F90', 'runlpb_sif.F90')
 endif
@@ -12,5 +19,7 @@ galahad_tests += [['lpb', 'lpbt', files('lpbt.F90')],
 
 galahad_c_tests += [['lpb', 'lpbt_c', files('C/lpbt.c')],
                     ['lpb', 'lpbtf_c', files('C/lpbtf.c')]]
+
+galahad_python_tests += [['lpb', 'lpb_py', files('Python/test_lpb.py')]]
 
 galahad_examples += [['lpbs', files('lpbs.f90')]]

--- a/src/lpb/meson.build
+++ b/src/lpb/meson.build
@@ -7,7 +7,12 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['lpb', files('Python/lpb_pyiface.c')]]
+  libgalahad_python_src += [['lpb', files('Python/lpb_pyiface.c',
+                                          '../sbls/Python/sbls_pyiface.c','../sls/Python/sls_pyiface.c','../uls/Python/uls_pyiface.c',
+                                          '../roots/Python/roots_pyiface.c','../sils/Python/sils_pyiface.c','../gls/Python/gls_pyiface.c',
+                                          '../fdc/Python/fdc_pyiface.c','../scu/Python/scu_pyiface.c','../fit/Python/fit_pyiface.c',
+                                          '../ir/Python/ir_pyiface.c','../cro/Python/cro_pyiface.c','../rpd/Python/rpd_pyiface.c',
+                                          '../lms/Python/lms_pyiface.c',)]]
 endif
 
 if libcutest.found()

--- a/src/lsqp/meson.build
+++ b/src/lsqp/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('lsqp.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lsqp_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['lsqp', files('Python/lsqp_pyiface.c')]]
 endif
 
 galahad_tests += [['lsqp', 'lsqpt', files('lsqpt.F90')],
@@ -8,6 +13,8 @@ galahad_tests += [['lsqp', 'lsqpt', files('lsqpt.F90')],
 
 galahad_c_tests += [['lsqp', 'lsqpt_c', files('C/lsqpt.c')],
                     ['lsqp', 'lsqptf_c', files('C/lsqptf.c')]]
+
+galahad_python_tests += [['lsqp', 'lsqp_py', files('Python/test_lsqp.py')]]
 
 galahad_examples += [['lsqps', files('lsqps.f90')],
                      ['lsqps2', files('lsqps2.f90')]]

--- a/src/lsqp/meson.build
+++ b/src/lsqp/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['lsqp', files('Python/lsqp_pyiface.c')]]
+  libgalahad_python_src += [['lsqp', files('Python/lsqp_pyiface.c',
+                                           '../sbls/Python/sbls_pyiface.c','../gltr/Python/gltr_pyiface.c','../sls/Python/sls_pyiface.c',
+                                           '../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c','../gls/Python/gls_pyiface.c',
+                                           '../fdc/Python/fdc_pyiface.c')]]
 endif
 
 galahad_tests += [['lsqp', 'lsqpt', files('lsqpt.F90')],

--- a/src/lsrt/meson.build
+++ b/src/lsrt/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('lsrt.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lsrt_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['lsrt', files('Python/lsrt_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselsrt.F90', 'runlsrt_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['lsrt', 'lsrtt', files('lsrtt.F90')],
                   ['lsrt', 'lsrtti', files('lsrtti.F90')]]
 
 galahad_c_tests += [['lsrt', 'lsrtt_c', files('C/lsrtt.c')]]
+
+galahad_python_tests += [['lsrt', 'lsrt_py', files('Python/test_lsrt.py')]]
 
 galahad_examples += [['lsrts', files('lsrts.f90')],
                      ['lsrts2', files('lsrts2.f90')]]

--- a/src/lstr/meson.build
+++ b/src/lstr/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('lstr.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/lstr_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['lstr', files('Python/lstr_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('uselstr.F90', 'runlstr_sif.F90')
 endif
@@ -10,6 +16,8 @@ galahad_tests += [['lstr', 'lstrt', files('lstrt.F90')],
                   ['lstr', 'lstrti', files('lstrti.F90')]]
 
 galahad_c_tests += [['lstr', 'lstrt_c', files('C/lstrt.c')]]
+
+galahad_python_tests += [['lstr', 'lstr_py', files('Python/test_lstr.py')]]
 
 galahad_examples += [['lstrs', files('lstrs.f90')],
                      ['lstrs2', files('lstrs2.f90')]]

--- a/src/nls/meson.build
+++ b/src/nls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('nls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/nls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['nls', files('Python/nls_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usenls.F90', 'runnls_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['nls', 'nlst', files('nlst.F90')],
 
 galahad_c_tests += [['nls', 'nlst_c', files('C/nlst.c')],
                     ['nls', 'nlstf_c', files('C/nlstf.c')]]
+
+galahad_python_tests += [['nls', 'nls_py', files('Python/test_nls.py')]]
 
 galahad_examples += [['nlss', files('nlss.f90')],
                      ['nlss2', files('nlss2.f90')],

--- a/src/nls/meson.build
+++ b/src/nls/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['nls', files('Python/nls_pyiface.c')]]
+  libgalahad_python_src += [['nls', files('Python/nls_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../gltr/Python/gltr_pyiface.c',
+                                          '../glrt/Python/glrt_pyiface.c','../rqs/Python/rqs_pyiface.c','../psls/Python/psls_pyiface.c',
+                                          '../bsc/Python/bsc_pyiface.c','../roots/Python/roots_pyiface.c','../sils/Python/sils_pyiface.c',)]]
 endif
 
 if libcutest.found()

--- a/src/presolve/meson.build
+++ b/src/presolve/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('presolve.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/presolve_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['presolve', files('Python/presolve_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usepresolve.F90', 'runpresolve_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['presolve', 'presolvet', files('presolvet.F90')],
 
 galahad_c_tests += [['presolve', 'presolvet_c', files('C/presolvet.c')],
                     ['presolve', 'presolvetf_c', files('C/presolvetf.c')]]
+
+galahad_python_tests += [['presolve', 'presolve_py', files('Python/test_presolve.py')]]
 
 galahad_examples += [['presolves', files('presolves.f90')]]

--- a/src/psls/meson.build
+++ b/src/psls/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('psls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/psls_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['psls', files('Python/psls_pyiface.c')]]
 endif
 
 galahad_tests += [['psls', 'pslst', files('pslst.F90')],
@@ -8,5 +13,7 @@ galahad_tests += [['psls', 'pslst', files('pslst.F90')],
 
 galahad_c_tests += [['psls', 'pslst_c', files('C/pslst.c')],
                     ['psls', 'pslstf_c', files('C/pslstf.c')]]
+
+galahad_python_tests += [['psls', 'psls_py', files('Python/test_psls.py')]]
 
 galahad_examples += [['pslss', files('pslss.f90')]]

--- a/src/psls/meson.build
+++ b/src/psls/meson.build
@@ -5,7 +5,8 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['psls', files('Python/psls_pyiface.c')]]
+  libgalahad_python_src += [['psls', files('Python/psls_pyiface.c',
+                                           '../sls/Python/sls_pyiface.c','../sils/Python/sils_pyiface.c')]]
 endif
 
 galahad_tests += [['psls', 'pslst', files('pslst.F90')],

--- a/src/qpa/meson.build
+++ b/src/qpa/meson.build
@@ -7,7 +7,9 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['qpa', files('Python/qpa_pyiface.c')]]
+  libgalahad_python_src += [['qpa', files('Python/qpa_pyiface.c',
+                                          '../sbls/Python/sbls_pyiface.c','../gltr/Python/gltr_pyiface.c','../sls/Python/sls_pyiface.c',
+                                          '../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c', '../gls/Python/gls_pyiface.c',)]]
 endif
 
 if libcutest.found()

--- a/src/qpa/meson.build
+++ b/src/qpa/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('qpa.F90')
+
 galahad_binaries += [['inqpa', files('inqpa.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/qpa_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['qpa', files('Python/qpa_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useqpa.F90', 'runqpa_sif.F90')
 endif
@@ -12,5 +19,7 @@ galahad_tests += [['qpa', 'qpat', files('qpat.F90')],
 
 galahad_c_tests += [['qpa', 'qpat_c', files('C/qpat.c')],
                     ['qpa', 'qpatf_c', files('C/qpatf.c')]]
+
+galahad_python_tests += [['qpa', 'qpa_py', files('Python/test_qpa.py')]]
 
 galahad_examples += [['qpas', files('qpas.f90')]]

--- a/src/qpb/meson.build
+++ b/src/qpb/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('qpb.F90')
+
 galahad_binaries += [['inqpb', files('inqpb.F90')]]
+
 if build_ciface
   libgalahad_c_src += files('C/qpb_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['qpb', files('Python/qpb_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useqpb.F90', 'runqpb_sif.F90')
 endif
@@ -12,6 +19,8 @@ galahad_tests += [['qpb', 'qpbt', files('qpbt.F90')],
 
 galahad_c_tests += [['qpb', 'qpbt_c', files('C/qpbt.c')],
                     ['qpb', 'qpbtf_c', files('C/qpbtf.c')]]
+
+galahad_python_tests += [['qpb', 'qpb_py', files('Python/test_qpb.py')]]
 
 galahad_examples += [['qpbs', files('qpbs.f90')],
                      ['qpbs2', files('qpbs2.f90')]]

--- a/src/qpb/meson.build
+++ b/src/qpb/meson.build
@@ -7,7 +7,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['qpb', files('Python/qpb_pyiface.c')]]
+  libgalahad_python_src += [['qpb', files('Python/qpb_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../sbls/Python/sbls_pyiface.c','../fit/Python/fit_pyiface.c',
+                                          '../gltr/Python/gltr_pyiface.c','../fdc/Python/fdc_pyiface.c','../lsqp/Python/lsqp_pyiface.c',
+                                          '../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c','../gls/Python/gls_pyiface.c',)]]
 endif
 
 if libcutest.found()

--- a/src/roots/meson.build
+++ b/src/roots/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('roots.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/roots_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['roots', files('Python/roots_pyiface.c')]]
+endif
+
 galahad_tests += [['roots', 'rootst', files('rootst.F90')]]
+
+galahad_python_tests += [['roots', 'roots_py', files('Python/test_roots.py')]]
 
 galahad_examples += [['rootss', files('rootss.f90')]]

--- a/src/rpd/meson.build
+++ b/src/rpd/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('rpd.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/rpd_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['rpd', files('Python/rpd_pyiface.c')]]
 endif
 
 galahad_tests += [['rpd', 'rpdt', files('rpdt.F90')],
@@ -8,5 +13,7 @@ galahad_tests += [['rpd', 'rpdt', files('rpdt.F90')],
 
 galahad_c_tests += [['rpd', 'rpdt_c', files('C/rpdt.c')],
                     ['rpd', 'rpdtf_c', files('C/rpdtf.c')]]
+
+galahad_python_tests += [['rpd', 'rpd_py', files('Python/test_rpd.py')]]
 
 galahad_examples += [['rpds', files('rpds.f90')]]

--- a/src/rqs/meson.build
+++ b/src/rqs/meson.build
@@ -5,7 +5,8 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['rqs', files('Python/rqs_pyiface.c')]]
+  libgalahad_python_src += [['rqs', files('Python/rqs_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../sils/Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/rqs/meson.build
+++ b/src/rqs/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('rqs.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/rqs_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['rqs', files('Python/rqs_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('userqs.F90', 'runrqs_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['rqs', 'rqst', files('rqst.F90')],
 
 galahad_c_tests += [['rqs', 'rqst_c', files('C/rqst.c')],
                     ['rqs', 'rqstf_c', files('C/rqstf.c')]]
+
+galahad_python_tests += [['rqs', 'rqs_py', files('Python/test_rqs.py')]]
 
 galahad_examples += [['rqss', files('rqss.f90')],
                      ['rqss2', files('rqss2.f90')]]

--- a/src/sbls/Python/sbls_pyiface.c
+++ b/src/sbls/Python/sbls_pyiface.c
@@ -514,14 +514,14 @@ static PyObject* py_sbls_load(PyObject *self, PyObject *args, PyObject *keywds){
                              "C_type","C_ne","C_row","C_col","C_ptr",
                              "options",NULL};
 
-    if(!PyArg_ParseTupleAndKeywords(args, keywds, "iisiOOOsiOOOsiOOO|O", 
-                                    kwlist, &n, &m, 
-                                    &H_type, &H_ne, &py_H_row, 
-                                    &py_H_col, &py_H_ptr, 
-                                    &A_type, &A_ne, &py_A_row, 
-                                    &py_A_col, &py_A_ptr, 
-                                    &C_type, &C_ne, &py_C_row, 
-                                    &py_C_col, &py_C_ptr, 
+    if(!PyArg_ParseTupleAndKeywords(args, keywds, "iisiOOOsiOOOsiOOO|O",
+                                    kwlist, &n, &m,
+                                    &H_type, &H_ne, &py_H_row,
+                                    &py_H_col, &py_H_ptr,
+                                    &A_type, &A_ne, &py_A_row,
+                                    &py_A_col, &py_A_ptr,
+                                    &C_type, &C_ne, &py_C_row,
+                                    &py_C_col, &py_C_ptr,
                                     &py_options))
         return NULL;
 
@@ -611,7 +611,7 @@ static PyObject* py_sbls_load(PyObject *self, PyObject *args, PyObject *keywds){
         return NULL;
 
     // Call sbls_analyse_matrix
-    sbls_import(&control, &data, &status, n, m, 
+    sbls_import(&control, &data, &status, n, m,
                 H_type, H_ne, H_row, H_col, H_ptr,
                 A_type, A_ne, A_row, A_col, A_ptr,
                 C_type, C_ne, C_row, C_col, C_ptr);
@@ -638,7 +638,8 @@ static PyObject* py_sbls_load(PyObject *self, PyObject *args, PyObject *keywds){
 //  *-*-*-*-*-*-*-*-*-*-*-*-   SBLS_FACTORIZE_MATRIX    -*-*-*-*-*-*-*-*-*-*-*-*
 
 static PyObject* py_sbls_factorize_matrix(PyObject *self, PyObject *args, PyObject *keywds){
-    PyArrayObject *py_H_val, *py_A_val, *py_C_val, *py_D;
+    PyArrayObject *py_H_val, *py_A_val, *py_C_val;
+    PyArrayObject *py_D = NULL;
     double *H_val, *A_val, *C_val, *D;
     int n, m, H_ne, A_ne, C_ne;
 
@@ -651,7 +652,7 @@ static PyObject* py_sbls_factorize_matrix(PyObject *self, PyObject *args, PyObje
                              "C_ne","C_val","D",NULL};
 
     if(!PyArg_ParseTupleAndKeywords(args, keywds, "iiiOiOiO|O",
-                                    kwlist, &n, &m, &H_ne, &py_H_val, &A_ne, 
+                                    kwlist, &n, &m, &H_ne, &py_H_val, &A_ne,
                                     &py_A_val, &C_ne, &py_C_val, &py_D ))
         return NULL;
 
@@ -666,10 +667,10 @@ static PyObject* py_sbls_factorize_matrix(PyObject *self, PyObject *args, PyObje
     H_val = (double *) PyArray_DATA(py_H_val);
     A_val = (double *) PyArray_DATA(py_A_val);
     C_val = (double *) PyArray_DATA(py_C_val);
-    D = (double *) PyArray_DATA(py_D);
+    if(py_D != NULL) D = (double *) PyArray_DATA(py_D);
 
     // Call sbls_factorize_matrix
-    sbls_factorize_matrix(&data, &status, n, H_ne, H_val, A_ne, A_val, 
+    sbls_factorize_matrix(&data, &status, n, H_ne, H_val, A_ne, A_val,
                           C_ne, C_val, D );
 
     // Raise any status errors
@@ -706,7 +707,7 @@ static PyObject* py_sbls_solve_system(PyObject *self, PyObject *args){
     // Call sbls_solve_direct
     sbls_solve_system(&data, &status, n, m, sol);
     // for( int i = 0; i < n; i++) printf("x %f\n", sol[i]);
-    
+
     // Propagate any errors with the callback function
     if(PyErr_Occurred())
         return NULL;
@@ -763,7 +764,7 @@ static PyObject* py_sbls_terminate(PyObject *self){
 static PyMethodDef sbls_module_methods[] = {
     {"initialize", (PyCFunction) py_sbls_initialize, METH_NOARGS,NULL},
     {"load", (PyCFunction) py_sbls_load, METH_VARARGS, NULL},
-    {"factorize_matrix", (PyCFunction) py_sbls_factorize_matrix, 
+    {"factorize_matrix", (PyCFunction) py_sbls_factorize_matrix,
       METH_VARARGS, NULL},
     {"solve_system", (PyCFunction) py_sbls_solve_system, METH_VARARGS, NULL},
     {"information", (PyCFunction) py_sbls_information, METH_NOARGS, NULL},

--- a/src/sbls/meson.build
+++ b/src/sbls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('sbls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sbls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['sbls', files('Python/sbls_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesbls.F90', 'runsbls_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['sbls', 'sblst', files('sblst.F90')],
 
 galahad_c_tests += [['sbls', 'sblst_c', files('C/sblst.c')],
                     ['sbls', 'sblstf_c', files('C/sblstf.c')]]
+
+galahad_python_tests += [['sbls', 'sbls_py', files('Python/test_sbls.py')]]
 
 galahad_examples += [['sblss', files('sblss.f90')]]

--- a/src/sbls/meson.build
+++ b/src/sbls/meson.build
@@ -5,7 +5,9 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['sbls', files('Python/sbls_pyiface.c')]]
+  libgalahad_python_src += [['sbls', files('Python/sbls_pyiface.c',
+                                           '../sls/Python/sls_pyiface.c','../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c',
+                                           '../gls/Python/gls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/scu/meson.build
+++ b/src/scu/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('scu.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/scu_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['scu', files('Python/scu_pyiface.c')]]
+endif
+
 galahad_tests += [['scu', 'scut', files('scut.F90')]]
+
+galahad_python_tests += [['scu', 'scu_py', files('Python/test_scu.py')]]
 
 galahad_examples += [['scus', files('scus.f90')]]

--- a/src/sec/meson.build
+++ b/src/sec/meson.build
@@ -1,8 +1,15 @@
 libgalahad_src += files('sec.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sec_ciface.F90')
 endif
 
+if build_pythoniface
+  libgalahad_python_src += [['sec', files('Python/sec_pyiface.c')]]
+endif
+
 galahad_tests += [['sec', 'sect', files('sect.F90')]]
+
+galahad_python_tests += [['sec', 'sec_py', files('Python/test_sec.py')]]
 
 galahad_examples += [['secs', files('secs.f90')]]

--- a/src/sha/meson.build
+++ b/src/sha/meson.build
@@ -1,11 +1,19 @@
 libgalahad_src += files('sha.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sha_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['sha', files('Python/sha_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesha.F90', 'runsha_sif.F90')
 endif
 
 galahad_tests += [['sha', 'shat', files('shat.F90')]]
+
+galahad_python_tests += [['sha', 'sha_py', files('Python/test_sha.py')]]
 
 galahad_examples += [['shas', files('shas.f90')]]

--- a/src/sils/meson.build
+++ b/src/sils/meson.build
@@ -1,11 +1,19 @@
 libgalahad_src += files('sils.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sils_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['sils', files('Python/sils_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesils.F90', 'runsils_sif.F90')
 endif
 
 galahad_tests += [['sils', 'silst', files('silst.F90')]]
+
+galahad_python_tests += [['sils', 'sils_py', files('Python/test_sils.py')]]
 
 galahad_examples += [['silss', files('silss.f90')]]

--- a/src/sls/makemaster
+++ b/src/sls/makemaster
@@ -36,7 +36,7 @@ CDEPENDS = ir_ciface sbls_ciface trs_ciface rqs_ciface
 #  auxiliary packages that the python interface to the current package depends
 #  on (prepend with make_pyiface_)
 
-PYDEPENDENCIES =
+PYDEPENDENCIES = make_pyiface_sils
 
 #  other python interface packages that depend on current interface package
 

--- a/src/sls/meson.build
+++ b/src/sls/meson.build
@@ -5,7 +5,8 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['sls', files('Python/sls_pyiface.c')]]
+  libgalahad_python_src += [['sls', files('Python/sls_pyiface.c',
+                                          '../sils/Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/sls/meson.build
+++ b/src/sls/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('sls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/sls_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['sls', files('Python/sls_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usesls.F90', 'runsls_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['sls', 'slst', files('slst.F90')],
 
 galahad_c_tests += [['sls', 'slst_c', files('C/slst.c')],
                     ['sls', 'slstf_c', files('C/slstf.c')]]
+
+galahad_python_tests += [['sls', 'sls_py', files('Python/test_sls.py')]]
 
 galahad_examples += [['slss', files('slss.f90')]]

--- a/src/trb/meson.build
+++ b/src/trb/meson.build
@@ -5,7 +5,10 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['trb', files('Python/trb_pyiface.c')]]
+  libgalahad_python_src += [['trb', files('Python/trb_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../trs/Python/trs_pyiface.c',
+                                          '../gltr/Python/gltr_pyiface.c','../psls/Python/psls_pyiface.c','../lms/Python/lms_pyiface.c',
+                                          '../sha/Python/sha_pyiface.c','../sils/Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/trb/meson.build
+++ b/src/trb/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('trb.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/trb_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['trb', files('Python/trb_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usetrb.F90', 'runtrb_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['trb', 'trbt', files('trbt.F90')],
 
 galahad_c_tests += [['trb', 'trbt_c', files('C/trbt.c')],
                     ['trb', 'trbtf_c', files('C/trbtf.c')]]
+
+galahad_python_tests += [['trb', 'trb_py', files('Python/test_trb.py')]]
 
 galahad_examples += [['trbs', files('trbs.f90')],
                      ['trbs2', files('trbs2.f90')],

--- a/src/trs/meson.build
+++ b/src/trs/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('trs.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/trs_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['trs', files('Python/trs_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usetrs.F90', 'runtrs_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['trs', 'trst', files('trst.F90')],
 
 galahad_c_tests += [['trs', 'trst_c', files('C/trst.c')],
                     ['trs', 'trstf_c', files('C/trstf.c')]]
+
+galahad_python_tests += [['trs', 'trs_py', files('Python/test_trs.py')]]
 
 galahad_examples += [['trss', files('trss.f90')],
                      ['trss2', files('trss2.f90')]]

--- a/src/trs/meson.build
+++ b/src/trs/meson.build
@@ -5,7 +5,8 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['trs', files('Python/trs_pyiface.c')]]
+  libgalahad_python_src += [['trs', files('Python/trs_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../sils/Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/tru/meson.build
+++ b/src/tru/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('tru.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/tru_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['tru', files('Python/tru_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usetru.F90', 'runtru_sif.F90')
 endif
@@ -11,6 +17,8 @@ galahad_tests += [['tru', 'trut', files('trut.F90')],
 
 galahad_c_tests += [['tru', 'trut_c', files('C/trut.c')],
                     ['tru', 'trutf_c', files('C/trutf.c')]]
+
+galahad_python_tests += [['tru', 'tru_py', files('Python/test_tru.py')]]
 
 galahad_examples += [['trus', files('trus.f90')],
                      ['trus2', files('trus2.f90')],

--- a/src/tru/meson.build
+++ b/src/tru/meson.build
@@ -5,7 +5,11 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['tru', files('Python/tru_pyiface.c')]]
+  libgalahad_python_src += [['tru', files('Python/tru_pyiface.c',
+                                          '../sls/Python/sls_pyiface.c','../ir/Python/ir_pyiface.c','../trs/Python/trs_pyiface.c',
+                                          '../gltr/Python/gltr_pyiface.c','../psls/Python/psls_pyiface.c','../dps/Python/dps_pyiface.c',
+                                          '../lms/Python/lms_pyiface.c','../sec/Python/sec_pyiface.c','../sha/Python/sha_pyiface.c',
+                                          '../sils/Python/sils_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/ugo/meson.build
+++ b/src/ugo/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('ugo.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/ugo_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['ugo', files('Python/ugo_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('useugo.F90', 'runugo_sif.F90')
 endif
@@ -9,6 +15,8 @@ endif
 galahad_tests += [['ugo', 'ugot', files('ugot.F90')]]
 
 galahad_c_tests += [['ugo', 'ugot_c', files('C/ugot.c')]]
+
+galahad_python_tests += [['ugo', 'ugo_py', files('Python/test_ugo.py')]]
 
 galahad_examples += [['ugos', files('ugos.f90')],
                      ['ugos2', files('ugos2.f90')],

--- a/src/uls/makemaster
+++ b/src/uls/makemaster
@@ -1,10 +1,10 @@
 #  Main body of the installation makefile for the GALAHAD ULS package
 
-#  Nick Gould, for GALAHAD productions 
+#  Nick Gould, for GALAHAD productions
 #  This version: 2023-05-11
 
 #  include standard GALAHAD makefile defaults before package-specifics
- 
+
 include $(GALAHAD)/src/makedefs/defaults
 
 #  ===========================================================================
@@ -24,19 +24,19 @@ DEPENDENCIES = make_uls_deps
 
 DEPENDS = sbls cro fdc
 
-#  auxiliary packages that the C interface to the current package depends 
+#  auxiliary packages that the C interface to the current package depends
 #  on (prepend with make_ciface_)
 
 CDEPENDENCIES = make_ciface_uls_deps
 
-#  other C interface packages that depend on current interface package 
+#  other C interface packages that depend on current interface package
 
 CDEPENDS = sbls_ciface cro_ciface fdc_ciface
 
 #  auxiliary packages that the python interface to the current package depends
 #  on (prepend with make_pyiface_)
 
-PYDEPENDENCIES =
+PYDEPENDENCIES = make_pyiface_gls
 
 #  other python interface packages that depend on current interface package
 
@@ -55,11 +55,11 @@ TESTS = test_full
 #  ===========================================================================
 
 #  include standard GALAHAD makefile definitions
- 
+
 include $(GALAHAD)/src/makedefs/definitions
 
 #  include compilation and run instructions
- 
+
 include $(GALAHAD)/src/makedefs/instructions
 
 #  include standard package compilation instructions
@@ -67,5 +67,5 @@ include $(GALAHAD)/src/makedefs/instructions
 include $(GALAHAD)/src/makedefs/compile
 
 #  include required package intermediaries
- 
+
 include $(GALAHAD)/src/makedefs/intermediaries

--- a/src/uls/meson.build
+++ b/src/uls/meson.build
@@ -1,6 +1,11 @@
 libgalahad_src += files('uls.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/uls_ciface.F90')
+endif
+
+if build_pythoniface
+  libgalahad_python_src += [['uls', files('Python/uls_pyiface.c')]]
 endif
 
 galahad_tests += [['uls', 'ulst', files('ulst.F90')],
@@ -8,5 +13,7 @@ galahad_tests += [['uls', 'ulst', files('ulst.F90')],
 
 galahad_c_tests += [['uls', 'ulst_c', files('C/ulst.c')],
                     ['uls', 'ulstf_c', files('C/ulstf.c')]]
+
+galahad_python_tests += [['uls', 'uls_py', files('Python/test_uls.py')]]
 
 galahad_examples += [['ulss', files('ulss.f90')]]

--- a/src/uls/meson.build
+++ b/src/uls/meson.build
@@ -5,7 +5,8 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['uls', files('Python/uls_pyiface.c')]]
+  libgalahad_python_src += [['uls', files('Python/uls_pyiface.c',
+                                          '../gls/Python/gls_pyiface.c')]]
 endif
 
 galahad_tests += [['uls', 'ulst', files('ulst.F90')],

--- a/src/wcp/meson.build
+++ b/src/wcp/meson.build
@@ -5,7 +5,9 @@ if build_ciface
 endif
 
 if build_pythoniface
-  libgalahad_python_src += [['wcp', files('Python/wcp_pyiface.c')]]
+  libgalahad_python_src += [['wcp', files('Python/wcp_pyiface.c',
+                                          '../sbls/Python/sbls_pyiface.c','../fdc/Python/fdc_pyiface.c','../sls/Python/sls_pyiface.c',
+                                          '../sils/Python/sils_pyiface.c','../uls/Python/uls_pyiface.c','../gls/Python/gls_pyiface.c')]]
 endif
 
 if libcutest.found()

--- a/src/wcp/meson.build
+++ b/src/wcp/meson.build
@@ -1,7 +1,13 @@
 libgalahad_src += files('wcp.F90')
+
 if build_ciface
   libgalahad_c_src += files('C/wcp_ciface.F90')
 endif
+
+if build_pythoniface
+  libgalahad_python_src += [['wcp', files('Python/wcp_pyiface.c')]]
+endif
+
 if libcutest.found()
   libgalahad_cutest_src += files('usewcp.F90', 'runwcp_sif.F90')
 endif
@@ -11,5 +17,7 @@ galahad_tests += [['wcp', 'wcpt', files('wcpt.F90')],
 
 galahad_c_tests += [['wcp', 'wcpt_c', files('C/wcpt.c')],
                     ['wcp', 'wcptf_c', files('C/wcptf.c')]]
+
+galahad_python_tests += [['wcp', 'wcp_py', files('Python/test_wcp.py')]]
 
 galahad_examples += [['wcps', files('wcps.f90')]]


### PR DESCRIPTION
Enable meson to build and test the GALAHAD Python interfaces. 

Also fix some minor bugs in the Python interfaces that were causing intermittent segfaults / test failures.