### PR TITLE
[CI] Compile GALAHAD with CUTEst

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,8 +42,18 @@ task:
     fi
     echo "JULIA_PROJECT_SUBDIR=GALAHAD.jl" >> $CIRRUS_ENV
     echo "GALAHAD=$CIRRUS_WORKING_DIR" >> $CIRRUS_ENV
+    echo "CUTEST=$CIRRUS_WORKING_DIR/../CUTEst" >> $CIRRUS_ENV
     echo "OMP_CANCELLATION=TRUE" >> $CIRRUS_ENV
     echo "OMP_PROC_BIND=TRUE" >> $CIRRUS_ENV
+  cutest_script: |
+    cd ..
+    wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
+    tar -xzvf v2.1.0.tar.gz
+    cd CUTEst-2.1.0
+    meson setup builddir -Dquadruple=true --prefix=$CUTEST
+    meson compile -C builddir
+    meson install -C builddir
+
   configure_script: |
     meson setup builddir --buildtype=debug \
                          -Dlibblas= \
@@ -52,7 +62,11 @@ task:
                          -Dtests=true \
                          -Dpythoniface=true \
                          -Dgalahad_int64=${INT64} \
-                         -Db_sanitize=address,undefined
+                         -Dlibcutest_single_path=$CUTEST/lib \
+                         -Dlibcutest_double_path=$CUTEST/lib \
+                         -Dlibcutest_single_modules=$CUTEST/modules \
+                         -Dlibcutest_double_modules=$CUTEST/modules
+                         # -Db_sanitize=address,undefined
   build_script: |
     meson compile -C builddir
   install_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,7 +53,8 @@ task:
     meson setup builddir --buildtype=debug \
                          --prefix=$CUTEST \
                          -Ddefault_library=shared \
-                         -Dquadruple=true
+                         -Dquadruple=true \
+                         -Dcutest_int64=${INT64}
     meson compile -C builddir
     meson install -C builddir
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,8 +64,8 @@ task:
                          -Dgalahad_int64=${INT64} \
                          -Dlibcutest_single_path=$CUTEST/lib \
                          -Dlibcutest_double_path=$CUTEST/lib \
-                         -Dlibcutest_single_modules=$CUTEST/modules \
-                         -Dlibcutest_double_modules=$CUTEST/modules
+                         -Dlibcutest_single_modules=../CUTEst/modules \
+                         -Dlibcutest_double_modules=../CUTEst/modules
                          # -Db_sanitize=address,undefined
   build_script: |
     meson compile -C builddir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,12 +38,20 @@ task:
       pkg install -y py39-pip meson cmake bash gcc12 openblas wget
       pip install numpy
       echo "JULIA_GALAHAD_LIBRARY_PATH=/usr/local/lib" >> $CIRRUS_ENV
+      echo "CUTEST_SINGLE_PATH=/usr/local/lib" >> $CIRRUS_ENV
+      echo "CUTEST_DOUBLE_PATH=/usr/local/lib" >> $CIRRUS_ENV
+      echo "CUTEST_SINGLE_MODULES=/usr/local/modules" >> $CIRRUS_ENV
+      echo "CUTEST_DOUBLE_MODULES=/usr/local/modules" >> $CIRRUS_ENV
       echo "FC=gfortran12" >> $CIRRUS_ENV
       echo "CC=gcc12" >> $CIRRUS_ENV
       echo "CXX=g++12" >> $CIRRUS_ENV
     else
       brew install python meson gcc@14 openblas numpy wget
       echo "JULIA_GALAHAD_LIBRARY_PATH=/opt/homebrew/lib" >> $CIRRUS_ENV
+      echo "CUTEST_SINGLE_PATH=/opt/homebrew/lib" >> $CIRRUS_ENV
+      echo "CUTEST_DOUBLE_PATH=/opt/homebrew/lib" >> $CIRRUS_ENV
+      echo "CUTEST_SINGLE_MODULES=/opt/homebrew/modules" >> $CIRRUS_ENV
+      echo "CUTEST_DOUBLE_MODULES=/opt/homebrew/modules" >> $CIRRUS_ENV
       echo "FC=gfortran-14" >> $CIRRUS_ENV
       echo "CC=gcc-14" >> $CIRRUS_ENV
       echo "CXX=g++-14" >> $CIRRUS_ENV
@@ -73,8 +81,12 @@ task:
                          -Dtests=true \
                          -Dpythoniface=true \
                          -Dgalahad_int64=${INT64} \
-                         -Dlibcutest_single=$CUTEST_SINGLE \
-                         -Dlibcutest_double=$CUTEST_DOUBLE
+                         -Dlibcutest_single=${CUTEST_SINGLE} \
+                         -Dlibcutest_double=${CUTEST_DOUBLE} \
+                         -Dlibcutest_single_path=${CUTEST_SINGLE_PATH} \
+                         -Dlibcutest_double_path=${CUTEST_DOUBLE_PATH} \
+                         -Dlibcutest_single_modules=${CUTEST_SINGLE_MODULES} \
+                         -Dlibcutest_double_modules=${CUTEST_DOUBLE_MODULES}
                          # -Db_sanitize=address,undefined
   build_script: |
     meson compile -C builddir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,24 +6,32 @@ task:
       env:
         - JULIA_VERSION: 1
         - INT64: "false"
+        - CUTEST_SINGLE: "cutest_single"
+        - CUTEST_DOUBLE: "cutest_double"
     - name: Meson / freebsd/gcc-12/Int64
       freebsd_instance:
         image: freebsd-13-3-release-amd64
       env:
         - JULIA_VERSION: 1
         - INT64: "true"
+        - CUTEST_SINGLE: "cutest_single_64"
+        - CUTEST_DOUBLE: "cutest_double_64"
     - name: Meson / macos-silicon/gcc-14/Int32
       macos_instance:
         image: ghcr.io/cirruslabs/macos-ventura-base:latest
       env:
         - JULIA_VERSION: 1
         - INT64: "false"
+        - CUTEST_SINGLE: "cutest_single"
+        - CUTEST_DOUBLE: "cutest_double"
     - name: Meson / macos-silicon/gcc-14/Int64
       macos_instance:
         image: ghcr.io/cirruslabs/macos-ventura-base:latest
       env:
         - JULIA_VERSION: 1
         - INT64: "true"
+        - CUTEST_SINGLE: "cutest_single_64"
+        - CUTEST_DOUBLE: "cutest_double_64"
   dependencies_script: |
     echo $(uname)
     if [ "$(uname)" = "FreeBSD" ]; then
@@ -66,6 +74,8 @@ task:
                          -Dtests=true \
                          -Dpythoniface=true \
                          -Dgalahad_int64=${INT64} \
+                         -Dlibcutest_single=$CUTEST_SINGLE \
+                         -Dlibcutest_double=$CUTEST_DOUBLE \
                          -Dlibcutest_single_path=$CUTEST/lib \
                          -Dlibcutest_double_path=$CUTEST/lib \
                          -Dlibcutest_single_modules=../CUTEst/modules \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,7 +59,6 @@ task:
     tar -xzvf v2.1.0.tar.gz
     cd CUTEst-2.1.0
     meson setup builddir --buildtype=debug \
-                         --prefix=$CUTEST \
                          -Ddefault_library=shared \
                          -Dquadruple=true \
                          -Dcutest_int64=${INT64}
@@ -75,11 +74,7 @@ task:
                          -Dpythoniface=true \
                          -Dgalahad_int64=${INT64} \
                          -Dlibcutest_single=$CUTEST_SINGLE \
-                         -Dlibcutest_double=$CUTEST_DOUBLE \
-                         -Dlibcutest_single_path=$CUTEST/lib \
-                         -Dlibcutest_double_path=$CUTEST/lib \
-                         -Dlibcutest_single_modules=../CUTEst/modules \
-                         -Dlibcutest_double_modules=../CUTEst/modules
+                         -Dlibcutest_double=$CUTEST_DOUBLE
                          # -Db_sanitize=address,undefined
   build_script: |
     meson compile -C builddir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,7 @@ task:
   cutest_script: |
     cd ..
     wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
-    tar -xzvf v2.1.0.tar.gz -C CUTEst-2.1.0
+    tar -xzvf v2.1.0.tar.gz
     cd CUTEst-2.1.0
     meson setup builddir --buildtype=debug \
                          --prefix=$CUTEST \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,10 @@ task:
     wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
     tar -xzvf v2.1.0.tar.gz
     cd CUTEst-2.1.0
-    meson setup builddir -Dquadruple=true --prefix=$CUTEST
+    meson setup builddir --buildtype=debug \
+                         --prefix=$CUTEST \
+                         -Ddefault_library=shared \
+                         -Dquadruple=true
     meson compile -C builddir
     meson install -C builddir
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,14 +27,14 @@ task:
   dependencies_script: |
     echo $(uname)
     if [ "$(uname)" = "FreeBSD" ]; then
-      pkg install -y py39-pip meson cmake bash gcc12 openblas
+      pkg install -y py39-pip meson cmake bash gcc12 openblas wget
       pip install numpy
       echo "JULIA_GALAHAD_LIBRARY_PATH=/usr/local/lib" >> $CIRRUS_ENV
       echo "FC=gfortran12" >> $CIRRUS_ENV
       echo "CC=gcc12" >> $CIRRUS_ENV
       echo "CXX=g++12" >> $CIRRUS_ENV
     else
-      brew install python meson gcc@14 openblas numpy
+      brew install python meson gcc@14 openblas numpy wget
       echo "JULIA_GALAHAD_LIBRARY_PATH=/opt/homebrew/lib" >> $CIRRUS_ENV
       echo "FC=gfortran-14" >> $CIRRUS_ENV
       echo "CC=gcc-14" >> $CIRRUS_ENV
@@ -48,7 +48,7 @@ task:
   cutest_script: |
     cd ..
     wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
-    tar -xzvf v2.1.0.tar.gz
+    tar -xzvf v2.1.0.tar.gz -C CUTEst-2.1.0
     cd CUTEst-2.1.0
     meson setup builddir --buildtype=debug \
                          --prefix=$CUTEST \

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -152,7 +152,7 @@ jobs:
           fi
           cd ..
           wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
-          tar -xzvf v2.1.0.tar.gz
+          tar --no-same-owner --no-same-permissions -xzvf v2.1.0.tar.gz
           cd CUTEst-2.1.0
           meson setup builddir --buildtype=debug \
                                --prefix=$CUTEST \

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -146,6 +146,10 @@ jobs:
       - name: Install CUTEst
         shell: bash
         run: |
+          INT64="false"
+          if [[ "${{matrix.int}}" == "64" ]]; then
+            INT64="true"
+          fi
           cd ..
           wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
           tar -xzvf v2.1.0.tar.gz
@@ -153,7 +157,8 @@ jobs:
           meson setup builddir --buildtype=debug \
                                --prefix=$CUTEST \
                                -Ddefault_library=shared \
-                               -Dquadruple=true
+                               -Dquadruple=true \
+                               -Dcutest_int64=${INT64}
           meson compile -C builddir
           meson install -C builddir
 

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -144,6 +144,7 @@ jobs:
 
 
       - name: Install CUTEst
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
           INT64="false"

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -218,8 +218,8 @@ jobs:
                                -Dc_link_args=${LD_CLASSIC} \
                                -Dlibcutest_single_path=$CUTEST/lib \
                                -Dlibcutest_double_path=$CUTEST/lib \
-                               -Dlibcutest_single_modules=$CUTEST/modules \
-                               -Dlibcutest_double_modules=$CUTEST/modules
+                               -Dlibcutest_single_modules=../CUTEst/modules \
+                               -Dlibcutest_double_modules=../CUTEst/modules
                                # -Db_sanitize=address,undefined
 
       - name: Build GALAHAD

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -111,17 +111,17 @@ jobs:
         shell: bash
         run: |
           if [[ "${{matrix.os}}" == "ubuntu-latest" ]]; then
-            echo "LIBRARY_PATH=$LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib" >> $GITHUB_ENV
-            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib" >> $GITHUB_ENV
+            echo "LIBRARY_PATH=$LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib:$GITHUB_WORKSPACE/../CUTEst/lib" >> $GITHUB_ENV
+            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib:$GITHUB_WORKSPACE/../CUTEst/lib" >> $GITHUB_ENV
           fi
           if [[ "${{matrix.os}}" == "macos-13" ]]; then
-            echo "LIBRARY_PATH=$LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib" >> $GITHUB_ENV
-            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib" >> $GITHUB_ENV
-            echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib" >> $GITHUB_ENV
-            echo "DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH:/opt/intel/oneapi/compiler/2023.2.0/mac/compiler/lib" >> $GITHUB_ENV
+            echo "LIBRARY_PATH=$LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib:$GITHUB_WORKSPACE/../CUTEst/lib" >> $GITHUB_ENV
+            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib:$GITHUB_WORKSPACE/../CUTEst/lib" >> $GITHUB_ENV
+            echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/galahad/lib:$GITHUB_WORKSPACE/../deps/lib:$GITHUB_WORKSPACE/../CUTEst/lib" >> $GITHUB_ENV
+            echo "DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH:/opt/intel/oneapi/compiler/2023.2.0/mac/compiler/lib:$GITHUB_WORKSPACE/../CUTEst/lib" >> $GITHUB_ENV
           fi
           # if [[ "${{matrix.os}}" == "windows-latest" ]]; then
-          #   echo "PATH=$PATH:/d/a/GALAHAD/GALAHAD/../deps/bin" >> $GITHUB_ENV
+          #   echo "PATH=$PATH:/d/a/GALAHAD/GALAHAD/../deps/bin:/d/a/GALAHAD/GALAHAD/../CUTEst/lib" >> $GITHUB_ENV
           # fi
 
       - name: Set environment variables for OpenMP
@@ -152,7 +152,7 @@ jobs:
           fi
           cd ..
           wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
-          tar -xzvf v2.1.0.tar.gz
+          tar -xzvf v2.1.0.tar.gz -C CUTEst-2.1.0
           cd CUTEst-2.1.0
           meson setup builddir --buildtype=debug \
                                --prefix=$CUTEST \

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -171,6 +171,7 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
+          mkdir -p ../CUTEst/modules
           CSTD="c99"
           CPPSTD="c++11"
           INT64="false"

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Meson and Ninja
         run: pip install meson ninja numpy
 
-      - name: Set the environment variables GALAHAD, JULIA_GALAHAD_LIBRARY_PATH, DEPS and LIBDIR
+      - name: Set the environment variables GALAHAD, CUTEST, JULIA_GALAHAD_LIBRARY_PATH, DEPS and LIBDIR
         shell: bash
         run: |
           echo "GALAHAD=$GITHUB_WORKSPACE" >> $GITHUB_ENV
@@ -79,6 +79,9 @@ jobs:
             echo "LIBDIR=bin" >> $GITHUB_ENV
             echo "JULIA_GALAHAD_LIBRARY_PATH=$GITHUB_WORKSPACE/galahad/bin" >> $GITHUB_ENV
           fi
+          # echo "ARCHDEFS=$GITHUB_WORKSPACE/../ARCHDefs" >> $GITHUB_ENV
+          # echo "SIFDECODE=$GITHUB_WORKSPACE/../SIFDecode" >> $GITHUB_ENV
+          echo "CUTEST=$GITHUB_WORKSPACE/../CUTEst" >> $GITHUB_ENV
 
       - name: Install dependencies
         shell: bash
@@ -138,6 +141,18 @@ jobs:
         if: matrix.compiler == 'intel'
         shell: bash
         run: echo "FC=ifort" >> $GITHUB_ENV
+
+
+      - name: Install CUTEst
+        shell: bash
+        run: |
+          cd ..
+          wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
+          tar -xzvf v2.1.0.tar.gz
+          cd CUTEst-2.1.0
+          meson setup builddir -Dquadruple=true --prefix=$CUTEST
+          meson compile -C builddir
+          meson install -C builddir
 
       - name: Setup GALAHAD
         shell: bash
@@ -201,7 +216,11 @@ jobs:
                                -Dliblapack=$LAPACK \
                                -Dfortran_link_args=${LD_CLASSIC} \
                                -Dc_link_args=${LD_CLASSIC} \
-                               -Db_sanitize=address,undefined
+                               -Dlibcutest_single_path=$CUTEST/lib \
+                               -Dlibcutest_double_path=$CUTEST/lib \
+                               -Dlibcutest_single_modules=$CUTEST/modules \
+                               -Dlibcutest_double_modules=$CUTEST/modules
+                               # -Db_sanitize=address,undefined
 
       - name: Build GALAHAD
         shell: bash

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -151,8 +151,13 @@ jobs:
             INT64="true"
           fi
           cd ..
-          wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
-          tar --no-same-owner --no-same-permissions -xzvf v2.1.0.tar.gz
+          if [[ "${{matrix.os}}" == "windows-latest" ]]; then
+            wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.zip
+            tar -xvf v2.1.0.zip
+          else
+            wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
+            tar -xzvf v2.1.0.tar.gz
+          fi
           cd CUTEst-2.1.0
           meson setup builddir --buildtype=debug \
                                --prefix=$CUTEST \
@@ -194,9 +199,6 @@ jobs:
             BLAS_PATH="$DEPS/deps/$LIBDIR"
             LAPACK_PATH="$DEPS/deps/$LIBDIR"
           fi
-          if [[ ( "${{matrix.os}}" == "windows-latest" && "${{matrix.compiler}}" == "gcc" ) ]]; then
-            FLDFLAGS="-lregex"
-          fi
           if [[ ( "${{matrix.compiler}}" == "intel-classic" && "${{matrix.os}}" == "windows-latest" ) || ( "${{matrix.compiler}}" == "intel" && "${{matrix.os}}" == "windows-latest" ) ]]; then
             SHARED_STATIC="static"
           fi
@@ -212,7 +214,6 @@ jobs:
                                --prefix=$GITHUB_WORKSPACE/galahad \
                                -Dc_std=$CSTD \
                                -Dcpp_std=$CPPSTD \
-                               -Dfortran_link_args=$FLDFLAGS \
                                -Dexamples=true \
                                -Dtests=true \
                                -Dssids=$SSIDS \

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -150,7 +150,10 @@ jobs:
           wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
           tar -xzvf v2.1.0.tar.gz
           cd CUTEst-2.1.0
-          meson setup builddir -Dquadruple=true --prefix=$CUTEST
+          meson setup builddir --buildtype=debug \
+                               --prefix=$CUTEST \
+                               -Ddefault_library=shared \
+                               -Dquadruple=true
           meson compile -C builddir
           meson install -C builddir
 

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -152,7 +152,7 @@ jobs:
           fi
           cd ..
           wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
-          tar -xzvf v2.1.0.tar.gz -C CUTEst-2.1.0
+          tar -xzvf v2.1.0.tar.gz
           cd CUTEst-2.1.0
           meson setup builddir --buildtype=debug \
                                --prefix=$CUTEST \

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -153,7 +153,7 @@ jobs:
           cd ..
           if [[ "${{matrix.os}}" == "windows-latest" ]]; then
             wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.zip
-            tar -xvf v2.1.0.zip
+            unzip v2.1.0.zip
           else
             wget https://github.com/ralna/CUTEst/archive/refs/tags/v2.1.0.tar.gz
             tar -xzvf v2.1.0.tar.gz
@@ -180,6 +180,8 @@ jobs:
           LAPACK_PATH=""
           PYTHON_INTERFACE="true"
           SHARED_STATIC="shared"
+          CUTEST_SINGLE="cutest_single"
+          CUTEST_DOUBLE="cutest_double"
           LD_CLASSIC=""
           if [[ "${{matrix.os}}" == "macos-13" ]]; then
             LD_CLASSIC="-Wl,-ld_classic"
@@ -198,6 +200,8 @@ jobs:
             LAPACK="openblas64_"
             BLAS_PATH="$DEPS/deps/$LIBDIR"
             LAPACK_PATH="$DEPS/deps/$LIBDIR"
+            CUTEST_SINGLE="cutest_single_64"
+            CUTEST_DOUBLE="cutest_double_64"
           fi
           if [[ ( "${{matrix.compiler}}" == "intel-classic" && "${{matrix.os}}" == "windows-latest" ) || ( "${{matrix.compiler}}" == "intel" && "${{matrix.os}}" == "windows-latest" ) ]]; then
             SHARED_STATIC="static"
@@ -225,6 +229,8 @@ jobs:
                                -Dliblapack=$LAPACK \
                                -Dfortran_link_args=${LD_CLASSIC} \
                                -Dc_link_args=${LD_CLASSIC} \
+                               -Dlibcutest_single=$CUTEST_SINGLE \
+                               -Dlibcutest_double=$CUTEST_DOUBLE \
                                -Dlibcutest_single_path=$CUTEST/lib \
                                -Dlibcutest_double_path=$CUTEST/lib \
                                -Dlibcutest_single_modules=../CUTEst/modules \

--- a/meson.build
+++ b/meson.build
@@ -109,10 +109,10 @@ libcutest_single_path = get_option('libcutest_single_path')
 libcutest_double_path = get_option('libcutest_double_path')
 libhwloc_path = get_option('libhwloc_path')
 
-libhwloc_include = get_option('libhwloc_include')
-libcutest_single_modules = get_option('libcutest_single_modules')
-libcutest_double_modules = get_option('libcutest_double_modules')
-libhsl_modules = get_option('libhsl_modules')
+libhwloc_include = include_directories(get_option('libhwloc_include'))
+libcutest_single_modules = include_directories(get_option('libcutest_single_modules'))
+libcutest_double_modules = include_directories(get_option('libcutest_double_modules'))
+libhsl_modules = include_directories(get_option('libhsl_modules'))
 
 # Dependencies
 libblas = fc.find_library(libblas_name, dirs : libblas_path, required : false)


### PR DESCRIPTION
We should `dlopen` the shared library like Ipopt to avoid the issue with missing symbols.