### PR TITLE
Test the option -DGALAHAD_64BIT_INTEGER

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -18,12 +18,22 @@ jobs:
             cc_cmd: gcc
             fc_cmd: gfortran
             cxx_cmd: g++
+            int64: false
+          - os: ubuntu-latest
+            compiler: gnu
+            compiler_version: 13
+            cc_cmd: gcc
+            fc_cmd: gfortran
+            cxx_cmd: g++
+            int64: true
+            allow_failure: true
           - os: ubuntu-latest
             compiler: intel-llvm
             compiler_version: 2023.2.0
             cc_cmd: icx
             fc_cmd: ifort
             cxx_cmd: icpx
+            int64: false
             allow_failure: true
           # - os: ubuntu-latest
           #   compiler: intel-llvm
@@ -45,9 +55,27 @@ jobs:
       - name: Install Meson and Ninja
         run: pip install meson ninja numpy
 
-      - name: Set the environment variable GALAHAD
+      - name: Set the environment variables GALAHAD and DEPS
         shell: bash
-        run: echo "GALAHAD=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        run: |
+          echo "GALAHAD=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "DEPS=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd $DEPS
+          mkdir deps
+          if [[ "${{matrix.int64}}" == "true" ]]; then
+            wget https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.11.tar.gz
+            tar -xzvf lapack-3.11.tar.gz -C deps
+            cd deps/lapack-*
+            mkdir build
+            cd build
+            cmake -DCMAKE_INSTALL_LIBDIR=$DEPS/lapack -DBUILD_SHARED_LIBS=ON -DBUILD_INDEX64=ON ..
+            make
+            make install
+          fi
 
       - name: Set the environment variable LD_LIBRARY_PATH
         if: matrix.os != 'windows-latest'
@@ -86,7 +114,13 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true
+          if [[ "${{matrix.int64}}" == "true" ]]; then
+            meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true -Dgalahad_int64=true \
+                                 -Dlibblas_path=$DEPS/lapack -Dliblapack_path=$DEPS/lapack \
+                                 -Dliblas=blas64 -Dliblapack=lapack64
+          else
+            meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true -Dgalahad_int64=false
+          fi
         env:
           CC: ${{ matrix.cc_cmd }}
           FC: ${{ matrix.fc_cmd }}

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -68,12 +68,12 @@ jobs:
           mkdir deps
           if [[ "${{matrix.int64}}" == "true" ]]; then
             wget https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.11.tar.gz
-            tar -xzvf lapack-3.11.tar.gz -C deps
+            tar -xzvf v3.11.tar.gz -C deps
             cd deps/lapack-*
             mkdir build
             cd build
             cmake -DCMAKE_INSTALL_LIBDIR=$DEPS/lapack -DBUILD_SHARED_LIBS=ON -DBUILD_INDEX64=ON ..
-            make
+            make -j4
             make install
           fi
 
@@ -117,7 +117,7 @@ jobs:
           if [[ "${{matrix.int64}}" == "true" ]]; then
             meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true -Dgalahad_int64=true \
                                  -Dlibblas_path=$DEPS/lapack -Dliblapack_path=$DEPS/lapack \
-                                 -Dliblas=blas64 -Dliblapack=lapack64
+                                 -Dlibblas=blas64 -Dliblapack=lapack64
           else
             meson setup builddir --prefix=$GITHUB_WORKSPACE/galahad -Dpythoniface=true -Dgalahad_int64=false
           fi

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,11 @@ endif
 install_modules = get_option('modules')
 galahad_int64 = get_option('galahad_int64')
 
+# 64 bits integer
+if galahad_int64
+  pp_options += '-DGALAHAD_64BIT_INTEGER'
+endif
+
 build_ciface = get_option('ciface')
 build_pythoniface = get_option('pythoniface')
 build_single = get_option('single')
@@ -111,11 +116,6 @@ libdmumps = fc.find_library('dmumps', dirs : libmumps_path, required : false)
 libmkl_pardiso = fc.find_library(libmkl_pardiso_name, dirs : libmkl_pardiso_path, required : false)
 libampl = fc.find_library(libampl_name, dirs : libampl_path, required : false)
 lm = cc.find_library('m', required : false)
-
-# 64 bits integer
-if galahad_int64
-  add_global_arguments('-DGALAHAD_64BIT_INTEGER', language : 'fortran')
-endif
 
 # OpenMP
 if fc.get_id() == 'nagfor'

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ endif
 
 # Options
 install_modules = get_option('modules')
+galahad_int64 = get_option('galahad_int64')
 
 build_ciface = get_option('ciface')
 build_pythoniface = get_option('pythoniface')
@@ -110,6 +111,11 @@ libdmumps = fc.find_library('dmumps', dirs : libmumps_path, required : false)
 libmkl_pardiso = fc.find_library(libmkl_pardiso_name, dirs : libmkl_pardiso_path, required : false)
 libampl = fc.find_library(libampl_name, dirs : libampl_path, required : false)
 lm = cc.find_library('m', required : false)
+
+# 64 bits integer
+if galahad_int64
+  add_global_arguments('-DGALAHAD_64BIT_INTEGER', language : 'fortran')
+endif
 
 # OpenMP
 if fc.get_id() == 'nagfor'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -193,3 +193,8 @@ option('libmetis_version',
        choices : ['4', '5'],
        value : '5',
        description : 'Version of the METIS library')
+
+option('galahad_int64',
+       type : 'boolean',
+       value : false,
+       description : 'option to use 64 bits integer')


### PR DESCRIPTION
@nimgould  @jfowkes 
I added an option `galahad_int64` in the Meson build system to compile with the flag  `-DGALAHAD_64BIT_INTEGER`.
Should I use a different name of does it make sense to you?

I also added a CI build that compiles BLAS and LAPACK with 64 bits integer such that we can test this option with continuous integration.

Note that we have many errors with this option (see [here](https://github.com/ralna/GALAHAD/suites/18429890758/artifacts/1068313560)).