### PR TITLE
[Meson] Remove the option to provide libmkl_pardiso

### DIFF
--- a/README.meson
+++ b/README.meson
@@ -51,7 +51,7 @@ Currently supported options with their default value:
 * `-Dlibmetis_version=5`: version of the METIS library;
 * `-Dgalahad_int64=false`: compile GALAHAD with 64-bit integer.
 
-Note that the MKL Pardiso linear solver is only available when GALAHAD
+Note that the Intel MKL Pardiso linear solver is only available when GALAHAD
 is compiled with Intel MKL.
 This implies that `libblas` or `liblapack` should be set to `mkl_rt`.
 

--- a/README.meson
+++ b/README.meson
@@ -34,7 +34,6 @@ Currently supported options with their default value:
 * `-Dlibpardiso=pardiso`: PARDISO library against which to link;
 * `-Dlibspmf=spmf`: SPMF library against which to link;
 * `-Dlibpastix=pastix`: PASTIX library against which to link;
-* `-Dlibmkl_pardiso=mkl_pardiso`: Intel MKL PARDISO library against which to link;
 * `-Dlibampl=ampl`: AMPL library against which to link;
 * `-Dlibblas_path=[]`: additional directories to search for the BLAS library;
 * `-Dliblapack_path=[]`: additional directories to search for the LAPACK library;
@@ -47,11 +46,14 @@ Currently supported options with their default value:
 * `-Dlibspmf_path=[]`: additional directories to search for the SPMF library;
 * `-Dlibpastix_path=[]`: additional directories to search for the PASTIX library;
 * `-Dlibmumps_path=[]`: additional directories to search for the MUMPS libraries;
-* `-Dlibmkl_pardiso_path=[]`: additional directories to search for the Intel MKL library;
 * `-Dlibampl_path=[]`: additional directories to search for the AMPL library library;
 * `-Dlibhsl_modules[]`: additional directories to search for the HSL modules;
 * `-Dlibmetis_version=5`: version of the METIS library;
 * `-Dgalahad_int64=false`: compile GALAHAD with 64-bit integer.
+
+Note that the MKL Pardiso linear solver is only available when GALAHAD
+is compiled with Intel MKL.
+This implies that `libblas` or `liblapack` should be set to `mkl_rt`.
 
 Non-default compilers can be selected by setting the `CC`, `CXX` and
 `FC` shell variables.  For instance,

--- a/meson.build
+++ b/meson.build
@@ -67,7 +67,6 @@ libumfpack_name = get_option('libumfpack')
 libpardiso_name = get_option('libpardiso')
 libspmf_name = get_option('libspmf')
 libpastix_name = get_option('libpastix')
-libmkl_pardiso_name = get_option('libmkl_pardiso')
 libampl_name = get_option('libampl')
 libcutest_single_name = get_option('libcutest_single')
 libcutest_double_name = get_option('libcutest_double')
@@ -82,7 +81,6 @@ libumfpack_path = get_option('libumfpack_path')
 libpardiso_path = get_option('libpardiso_path')
 libspmf_path = get_option('libspmf_path')
 libpastix_path = get_option('libpastix_path')
-libmkl_pardiso_path = get_option('libmkl_pardiso_path')
 libampl_path = get_option('libampl_path')
 libcutest_single_path = get_option('libcutest_single_path')
 libcutest_double_path = get_option('libcutest_double_path')
@@ -107,7 +105,6 @@ libspmf = fc.find_library(libspmf_name, dirs : libspmf_path, required : false)
 libpastix = fc.find_library(libpastix_name, dirs : libpastix_path, required : false)
 libsmumps = fc.find_library('smumps', dirs : libmumps_path, required : false)
 libdmumps = fc.find_library('dmumps', dirs : libmumps_path, required : false)
-libmkl_pardiso = fc.find_library(libmkl_pardiso_name, dirs : libmkl_pardiso_path, required : false)
 libampl = fc.find_library(libampl_name, dirs : libampl_path, required : false)
 lm = cc.find_library('m', required : false)
 
@@ -140,7 +137,7 @@ libgalahad_single_deps = [libsmumps, libcutest_single]
 libgalahad_double_deps = [libdmumps, libcutest_double]
 libgalahad_deps = [libblas, liblapack, libmetis, libhsl, libwsmp,
                    libumfpack, libpardiso, libspmf, libpastix,
-                   libmkl_pardiso, libampl, libmpi, libhwloc]
+                   libampl, libmpi, libhwloc]
 
 libgalahad_single_src = []
 libgalahad_double_src = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -93,11 +93,6 @@ option('libpastix',
        value : 'pastix',
        description : 'PASTIX library against which to link')
 
-option('libmkl_pardiso',
-       type : 'string',
-       value : 'mkl_rt',
-       description : 'Intel MKL PARDISO library against which to link')
-
 option('libampl',
        type : 'string',
        value : 'ampl',
@@ -162,11 +157,6 @@ option('libmumps_path',
        type : 'array',
        value : [],
        description : 'Additional directories to search for the MUMPS libraries')
-
-option('libmkl_pardiso_path',
-       type : 'array',
-       value : [],
-       description : 'Additional directories to search for the Intel MKL library')
 
 option('libampl_path',
        type : 'array',

--- a/src/dum/meson.build
+++ b/src/dum/meson.build
@@ -64,7 +64,7 @@ if not libdmumps.found()
   galahad_headers += files('include/dmumps_struc.h')
 endif
 
-if not libmkl_pardiso.found()
+if not (libblas == 'mkl_rt' or liblapack == 'mkl_rt')
   libgalahad_src += files('mkl_pardiso.F90')
 endif
 

--- a/src/dum/meson.build
+++ b/src/dum/meson.build
@@ -64,7 +64,7 @@ if not libdmumps.found()
   galahad_headers += files('include/dmumps_struc.h')
 endif
 
-if not (libblas == 'mkl_rt' or liblapack == 'mkl_rt')
+if not (libblas_name == 'mkl_rt' or liblapack_name == 'mkl_rt')
   libgalahad_src += files('mkl_pardiso.F90')
 endif
 


### PR DESCRIPTION
@nimgould 
I removed the option to specify a library for MKL Pardiso because the library `mkl_rt` already includes the BLAS and LAPACK symbols.
Using two libraries, such as libopenblas.so and libmkl_rt.so, may lead to potential issues.
To determine if Intel MKL Pardiso is available, I now simply check the values of `libblas` and `liblapack`.