### PR TITLE
Fix lapack/meson.build

### DIFF
--- a/src/lapack/meson.build
+++ b/src/lapack/meson.build
@@ -2,15 +2,15 @@ libgalahad_src += files('blas_interface.F90', 'lapack_interface.F90')
 
 if not libblas.found()
   warning('building our own BLAS v3.9.1; consider providing an optimized BLAS library')
-  libgalahad_f_src += files('blas.f90')
+  libgalahad_src += files('blas.f90')
 endif
 
 if not liblapack.found()
   warning('building our own LAPACK v3.9.1; consider providing an optimized LAPACK library')
-  libgalahad_f_src += files('lapack.f90')
+  libgalahad_src += files('lapack.f90')
   if fc.get_id() == 'nagfor'
-    libgalahad_f_src += files('noieeeck.f90')
+    libgalahad_src += files('noieeeck.f90')
   else
-    libgalahad_f_src += files('ieeeck.f90')
+    libgalahad_src += files('ieeeck.f90')
   endif
 endif


### PR DESCRIPTION
close #233

@nimgould 
`libgalahad_f_src` is for `*.f` files.
`libgalahad_src` is for `*.f90` or `*.F90` files.
I explained it [here](https://github.com/ralna/GALAHAD/blob/master/meson.build#L168-L214).

Should I also add it in the `README.meson`?