### PR TITLE
Fix more issue for 64-bit integer

### DIFF
--- a/include/metis.h
+++ b/include/metis.h
@@ -30,8 +30,11 @@
  GCC does provides these definitions in stdint.h, but it may require some
  modifications on other architectures.
 --------------------------------------------------------------------------*/
-#define IDXTYPEWIDTH 32
-
+#ifdef GALAHAD_64BIT_INTEGER
+  #define IDXTYPEWIDTH 64
+#else
+  #define IDXTYPEWIDTH 32
+#endif
 
 /*--------------------------------------------------------------------------
  Specifies the data type that will hold floating-point style information.

--- a/meson.build
+++ b/meson.build
@@ -630,7 +630,7 @@ if build_tests and build_pythoniface and build_ciface and build_double and host_
 endif
 
 # Fortran examples
-if build_examples and build_double
+if build_examples and build_double and (not galahad_int64)
 
   fortran_examples_folder = 'examples/Fortran'
 


### PR DESCRIPTION
- Support 64-bit integer version of METIS;
- Fix a bug with `croti.F90`;
- Don't compile the examples with the 64-bit integer version of GALAHAD.