### PR TITLE
[CI] Update Intel compilers

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -19,19 +19,19 @@ jobs:
           - compiler: gcc
           - os: windows-latest
             compiler: intel-classic
-            version: '2021.10'
+            version: '2021.12'
             int: '32'
           - os: windows-latest
             compiler: intel-classic
-            version: '2021.10'
+            version: '2021.12'
             int: '64'
           - os: ubuntu-latest
             compiler: intel-classic
-            version: '2021.10'
+            version: '2021.12'
             int: '32'
           - os: ubuntu-latest
             compiler: intel-classic
-            version: '2021.10'
+            version: '2021.12'
             int: '64'
           # - os: macos-13
           #   compiler: intel-classic
@@ -43,19 +43,19 @@ jobs:
           #   int: '64'
           - os: windows-latest
             compiler: intel
-            version: '2023.2'
+            version: '2024.1'
             int: '32'
           - os: windows-latest
             compiler: intel
-            version: '2023.2'
+            version: '2024.1'
             int: '64'
           - os: ubuntu-latest
             compiler: intel
-            version: '2023.2'
+            version: '2024.1'
             int: '32'
           - os: ubuntu-latest
             compiler: intel
-            version: '2023.2'
+            version: '2024.1'
             int: '64'
           # - os: ubuntu-latest
           #   compiler: nvidia-hpc


### PR DESCRIPTION
I update the action `setup-fortran` [here](https://github.com/fortran-lang/setup-fortran/pull/93) but I suppose that Intel changed the location of the compilers...
I will fix that later.