### PR TITLE
[CI] Add a new workflow check_headers.jl

### DIFF
--- a/.github/julia/check_headers.jl
+++ b/.github/julia/check_headers.jl
@@ -79,6 +79,7 @@ function C_structures()
       path = joinpath(root, file) |> normpath
       if endswith(file, ".h")
         (file == "ssids_gpu_kernels_datatypes.h") && continue
+        (file == "ssids_gpu_kernels_dtrsv.h") && continue
         (file == "galahad_icfs.h") && continue
         code = read(path, String)
         lines = split(code, '\n')

--- a/.github/julia/check_headers.jl
+++ b/.github/julia/check_headers.jl
@@ -35,7 +35,6 @@ function FORTRAN_structures()
                 type = split(line, "::")[1] |> strip
                 field = split(line, "::")[2] |> strip
               end
-              field = split(field, "/")[1]
 
               field = split(field, "!")[1] |> strip
               for syntax in ("TYPE", "REAL", "INTEGER", "CHARACTER", "=")
@@ -103,6 +102,7 @@ function C_structures()
             if startswith(line, "};")
               c_struct = ""
             else
+              line = split(line, '/')[1]
               type = split(line)[end-1]
               field = split(line)[end][1:end-1]  # remove ";" at the end
               if contains(field, "[") && contains(field, "]")

--- a/.github/julia/check_headers.jl
+++ b/.github/julia/check_headers.jl
@@ -1,0 +1,174 @@
+using Test
+
+global n = 0
+
+function FORTRAN_structures()
+  f_types = Dict{String,Vector{String}}()
+  f_structures = Dict{String,Vector{String}}()
+
+  # Extract the Fortran structures from the Frotran files *_ciface.F90
+  f_struct = ""
+  for (root, dirs, files) in walkdir(joinpath(@__DIR__, "..", "..", "src"))
+    for file in files
+      path = joinpath(root, file) |> normpath
+      if endswith(file, "_ciface.F90")
+        code = read(path, String)
+        lines = split(code, '\n')
+        for (i, line) in enumerate(lines)
+          startswith(line, "!") && continue
+          if f_struct == ""
+            if contains(line |> uppercase, "TYPE, BIND( C )")
+              f_struct = split(line, "::")[2] |> strip
+              f_struct = lowercase(f_struct)
+              f_types[f_struct] = String[]
+              f_structures[f_struct] = String[]
+            end
+          else
+            if contains(line |> uppercase, "END TYPE")
+              f_struct = ""
+            else
+              if endswith(lines[i-1], "&")
+                type = split(lines[i-1], "::")[1] |> strip
+                field = strip(line)
+              else
+                type = split(line, "::")[1] |> strip
+                field = split(line, "::")[2] |> strip
+              end
+
+              field = split(field, "!")[1] |> strip
+              for syntax in ("TYPE", "REAL", "INTEGER", "CHARACTER", "=")
+                type = split(type, syntax)[end]
+              end
+              type = replace(type, "longc_" => "int64_t")
+              type = replace(type, "C_CHAR" => "char")
+              type = replace(type, "C_BOOL" => "bool")
+              type = replace(type, "(" => "")
+              type = replace(type, "," => "")
+              type = replace(type, ")" => "")
+              for dim in ("DIMENSION", "dimension")
+                if contains(type, dim)
+                  type = replace(type, dim => "[")
+                  type = type * "]"
+                end
+              end
+              type = lowercase(type)
+              type = replace(type, " " => "")
+
+              push!(f_types[f_struct], type)
+              push!(f_structures[f_struct], field)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return f_types, f_structures
+end
+
+function C_structures()
+  c_types = Dict{String,Vector{String}}()
+  c_structures = Dict{String,Vector{String}}()
+
+  # Extract the C structures from the header files *.h
+  c_struct = ""
+  for (root, dirs, files) in walkdir(joinpath(@__DIR__, "..", "..", "include"))
+    for file in files
+      path = joinpath(root, file) |> normpath
+      if endswith(file, ".h") && (file != "ssids_gpu_kernels_datatypes.h")
+        code = read(path, String)
+        lines = split(code, '\n')
+        for (i, line) in enumerate(lines)
+          line2 = line |> strip
+          length(line2) == 0 && continue
+          startswith(line2, "/") && continue
+          startswith(line2, "#") && continue
+          startswith(line2, "*") && continue
+          startswith(line2, "extern") && continue
+          if c_struct == ""
+            if startswith(line, "struct") && endswith(line, "{")
+              c_struct = split(line, "struct")[2]
+              c_struct = split(c_struct, "{")[1] |> strip
+              c_struct = lowercase(c_struct)
+              c_types[c_struct] = String[]
+              c_structures[c_struct] = String[]
+            end
+          else
+            if startswith(line, "};")
+              c_struct = ""
+            else
+              type = split(line)[end-1]
+              field = split(line)[end][1:end-1]  # remove ";" at the end
+              if contains(field, "[") && contains(field, "]")
+                dimension = split(field, "[")[2]
+                type = type * "[$dimension"
+                field = split(field, "[")[1]
+              end
+              type = replace(type, "real_sp_" => "spc_")
+              push!(c_types[c_struct], type)
+              push!(c_structures[c_struct], field)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return c_types, c_structures
+end
+
+f_types, f_structures = FORTRAN_structures()
+c_types, c_structures = C_structures()
+
+f_list = keys(f_structures)
+c_list = keys(c_structures)
+
+println("-------------------------------------------------------------")
+println("The following structures are only defined in the header files")
+println("-------------------------------------------------------------")
+for val in c_list
+  if !(val in f_list)
+    # Check if it's a structure of an HSL package
+    if !startswith(val, "ma") && !startswith(val, "mi") && !startswith(val, "mc")
+      println(val)
+      global n += 1
+    end
+  end
+end
+println("-------------------------------------------------------------")
+println()
+println("-------------------------------------------------------------")
+println("-----------------Check errors in structures------------------")
+println("-------------------------------------------------------------")
+for structure in f_list
+  if !(structure in c_list)
+    println("The structure $structure can't be find in an header file.")
+    global n += 1
+  else
+    f_nfields = length(f_structures[structure])
+    c_nfields = length(c_structures[structure])
+    if f_nfields != c_nfields
+      println("The structure $structure has missing attributes ($c_nfields / $f_nfields).")
+      global n += 1
+    else
+      for i = 1:c_nfields
+        c_field = c_structures[structure][i]
+        f_field = f_structures[structure][i]
+        if c_field != f_field
+          println("The field $i of the structure $structure is not consistent ($c_field / $f_field).")
+          global n += 1
+        else
+          c_type = c_types[structure][i]
+          f_type = f_types[structure][i]
+          if c_type != f_type
+            println("The type of field $(c_field) of the structure $structure is not consistent ($c_type / $f_type).")
+            global n += 1
+          end
+        end
+      end
+    end
+  end
+end
+println("-------------------------------------------------------------")
+
+@test n == 0

--- a/.github/julia/check_headers.jl
+++ b/.github/julia/check_headers.jl
@@ -27,6 +27,7 @@ function FORTRAN_structures()
             if contains(line |> uppercase, "END TYPE")
               f_struct = ""
             else
+              endswith(line, "&") && continue
               if endswith(lines[i-1], "&")
                 type = split(lines[i-1], "::")[1] |> strip
                 field = strip(line)

--- a/.github/julia/check_headers.jl
+++ b/.github/julia/check_headers.jl
@@ -35,6 +35,7 @@ function FORTRAN_structures()
                 type = split(line, "::")[1] |> strip
                 field = split(line, "::")[2] |> strip
               end
+              field = split(field, "/")[1]
 
               field = split(field, "!")[1] |> strip
               for syntax in ("TYPE", "REAL", "INTEGER", "CHARACTER", "=")
@@ -155,7 +156,7 @@ println("-----------------Check errors in structures------------------")
 println("-------------------------------------------------------------")
 for structure in f_list
   if !(structure in c_list)
-    println("The structure $structure can't be find in an header file.")
+    println("The structure $structure can't be find in a header file.")
     global n += 1
   else
     f_nfields = length(f_structures[structure])

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -1,0 +1,21 @@
+name: Headers
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: GALAHAD -- Check macros
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GALAHAD
+        uses: actions/checkout@v4
+      - name: Install Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: 1
+          arch: x64
+      - name: Check the C headers
+        run: julia --color=yes .github/julia/check_headers.jl

--- a/GALAHAD.jl/src/wrappers/arc.jl
+++ b/GALAHAD.jl/src/wrappers/arc.jl
@@ -81,8 +81,8 @@ struct arc_inform_type{T}
   f_eval::Cint
   g_eval::Cint
   h_eval::Cint
-  factorization_status::Cint
   factorization_max::Cint
+  factorization_status::Cint
   max_entries_factors::Int64
   factorization_integer::Int64
   factorization_real::Int64

--- a/GALAHAD.jl/src/wrappers/bnls.jl
+++ b/GALAHAD.jl/src/wrappers/bnls.jl
@@ -16,7 +16,6 @@ struct bnls_subproblem_control_type{T}
   norm::Cint
   non_monotone::Cint
   weight_update_strategy::Cint
-  infinity::T
   stop_c_absolute::T
   stop_c_relative::T
   stop_g_absolute::T

--- a/GALAHAD.jl/src/wrappers/rpd.jl
+++ b/GALAHAD.jl/src/wrappers/rpd.jl
@@ -15,10 +15,10 @@ export rpd_inform_type
 struct rpd_inform_type
   status::Cint
   alloc_status::Cint
-  bad_alloc::NTuple{81,Cchar}
   io_status::Cint
   line::Cint
   p_type::NTuple{4,Cchar}
+  bad_alloc::NTuple{81,Cchar}
 end
 
 export rpd_initialize

--- a/GALAHAD.jl/src/wrappers/sha.jl
+++ b/GALAHAD.jl/src/wrappers/sha.jl
@@ -7,8 +7,8 @@ struct sha_control_type
   print_level::Cint
   approximation_algorithm::Cint
   dense_linear_solver::Cint
-  sparse_row::Cint
   extra_differences::Cint
+  sparse_row::Cint
   recursion_max::Cint
   recursion_entries_required::Cint
   average_off_diagonals::Bool

--- a/GALAHAD.jl/src/wrappers/ssids.jl
+++ b/GALAHAD.jl/src/wrappers/ssids.jl
@@ -12,8 +12,8 @@ struct spral_ssids_options{T}
   use_gpu::Bool
   gpu_only::Bool
   min_gpu_work::Int64
-  max_load_inbalance::Cfloat
-  gpu_perf_coeff::Cfloat
+  max_load_inbalance::Float32
+  gpu_perf_coeff::Float32
   scaling::Cint
   small_subtree_threshold::Int64
   cpu_block_size::Cint
@@ -23,7 +23,7 @@ struct spral_ssids_options{T}
   u::T
   nstream::Cint
   multiplier::T
-  min_loadbalance::Cfloat
+  min_loadbalance::Float32
   failed_pivot_method::Cint
 end
 

--- a/GALAHAD.jl/src/wrappers/trb.jl
+++ b/GALAHAD.jl/src/wrappers/trb.jl
@@ -84,8 +84,8 @@ struct trb_inform_type{T}
   g_eval::Cint
   h_eval::Cint
   n_free::Cint
-  factorization_max::Cint
   factorization_status::Cint
+  factorization_max::Cint
   max_entries_factors::Int64
   factorization_integer::Int64
   factorization_real::Int64

--- a/include/galahad_arc.h
+++ b/include/galahad_arc.h
@@ -592,12 +592,12 @@ struct arc_inform_type {
     ipc_ h_eval;
 
     /// \brief
-    /// the return status from the factorization
-    ipc_ factorization_status;
-
-    /// \brief
     /// the maximum number of factorizations in a sub-problem solve
     ipc_ factorization_max;
+
+    /// \brief
+    /// the return status from the factorization
+    ipc_ factorization_status;
 
     /// \brief
     /// the maximum number of entries in the factors

--- a/include/galahad_bgo.h
+++ b/include/galahad_bgo.h
@@ -403,7 +403,7 @@ struct bgo_inform_type {
 
     /// \brief
     /// the status of the last attempted allocation/deallocation
-    ipc_ alloc_status ;
+    ipc_ alloc_status;
 
     /// \brief
     /// the name of the array for which an allocation/deallocation error

--- a/include/galahad_bnls.h
+++ b/include/galahad_bnls.h
@@ -530,7 +530,7 @@ struct bnls_subproblem_control_type {
 
     /// \brief
     /// any bound larger than infinity in modulus will be regarded as infinite
-    rpc_ infinity;
+    /// ---> rpc_ infinity; <---
 
     /// \brief
     /// overall convergence tolerances. The iteration will terminate when

--- a/include/galahad_rpd.h
+++ b/include/galahad_rpd.h
@@ -283,11 +283,6 @@ struct rpd_inform_type {
     ipc_ alloc_status;
 
     /// \brief
-    /// the name of the array for which an allocation or deallocation
-    /// error occurred
-    char bad_alloc[81];
-
-    /// \brief
     /// status from last read attempt
     ipc_ io_status;
 
@@ -298,6 +293,11 @@ struct rpd_inform_type {
     /// \brief
     /// problem type
     char p_type[4];
+
+    /// \brief
+    /// the name of the array for which an allocation or deallocation
+    /// error occurred
+    char bad_alloc[81];
 };
 
 // *-*-*-*-*-*-*-*-*-*-    R P D  _ I N I T I A L I Z E    -*-*-*-*-*-*-*-*-*

--- a/include/galahad_sha.h
+++ b/include/galahad_sha.h
@@ -204,12 +204,12 @@ struct sha_control_type {
     ipc_ dense_linear_solver;
 
     /// \brief
-    /// rows with no more that sparse_row entries are considered sparse
-    ipc_ sparse_row;
-
-    /// \brief
     /// if available use an addition extra_differences differences
     ipc_ extra_differences;
+
+    /// \brief
+    /// rows with no more that sparse_row entries are considered sparse
+    ipc_ sparse_row;
 
     /// \brief
     /// if a recursive algorithm is used (Alg 2.4), limit on the maximum number 

--- a/include/galahad_trb.h
+++ b/include/galahad_trb.h
@@ -611,12 +611,12 @@ struct trb_inform_type {
     ipc_ n_free;
 
     /// \brief
-    /// the maximum number of factorizations in a sub-problem solve
-    ipc_ factorization_max;
-
-    /// \brief
     /// the return status from the factorization
     ipc_ factorization_status;
+
+    /// \brief
+    /// the maximum number of factorizations in a sub-problem solve
+    ipc_ factorization_max;
 
     /// \brief
     /// the maximum number of entries in the factors

--- a/include/galahad_tru.h
+++ b/include/galahad_tru.h
@@ -545,7 +545,7 @@ struct tru_inform_type {
 
     /// \brief
     /// the status of the last attempted allocation/deallocation
-    ipc_ alloc_status ;
+    ipc_ alloc_status;
 
     /// \brief
     /// the name of the array for which an allocation/deallocation error

--- a/include/galahad_ugo.h
+++ b/include/galahad_ugo.h
@@ -283,7 +283,7 @@ struct ugo_inform_type {
 
     /// \brief
     /// the status of the last attempted allocation/deallocation
-    ipc_ alloc_status ;
+    ipc_ alloc_status;
 
     /// \brief
     /// the name of the array for which an allocation/deallocation error

--- a/include/spral_ssids.h
+++ b/include/spral_ssids.h
@@ -33,11 +33,11 @@ struct spral_ssids_options {
    bool ignore_numa;
    bool use_gpu;
    bool gpu_only;
-   longc_ min_gpu_work;
-   float max_load_inbalance;
-   float gpu_perf_coeff;
+   int64_t min_gpu_work;
+   real_sp_ max_load_inbalance;
+   real_sp_ gpu_perf_coeff;
    ipc_ scaling;
-   longc_ small_subtree_threshold;
+   int64_t small_subtree_threshold;
    ipc_ cpu_block_size;
    bool action;
    ipc_ pivot_method;
@@ -45,7 +45,7 @@ struct spral_ssids_options {
    rpc_ u;
    ipc_ nstream;
    rpc_ multiplier;
-   float min_loadbalance;
+   real_sp_ min_loadbalance;
    ipc_ failed_pivot_method;
    // char unused[80]; // Allow for future expansion
 };
@@ -60,8 +60,8 @@ struct spral_ssids_inform {
    ipc_ maxfront;
    ipc_ maxsupernode;
    ipc_ num_delay;
-   longc_ num_factor;
-   longc_ num_flops;
+   int64_t num_factor;
+   int64_t num_flops;
    ipc_ num_neg;
    ipc_ num_sup;
    ipc_ num_two;
@@ -71,8 +71,8 @@ struct spral_ssids_inform {
    ipc_ not_first_pass;
    ipc_ not_second_pass;
    ipc_ nparts;
-   longc_ cpu_flops;
-   longc_ gpu_flops;
+   int64_t cpu_flops;
+   int64_t gpu_flops;
    // char unused[76]; // Allow for future expansion
 };
 
@@ -83,7 +83,7 @@ struct spral_ssids_inform {
 /* Initialize options to defaults */
 void spral_ssids_default_options(struct spral_ssids_options *options);
 /* Perform analysis phase for CSC data */
-void spral_ssids_analyse(bool check, ipc_ n, ipc_ *order, const longc_ *ptr,
+void spral_ssids_analyse(bool check, ipc_ n, ipc_ *order, const int64_t *ptr,
       const ipc_ *row, const rpc_ *val, void **akeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
@@ -92,12 +92,12 @@ void spral_ssids_analyse_ptr32(bool check, ipc_ n, ipc_ *order, const ipc_ *ptr,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
 /* Perform analysis phase for coordinate data */
-void spral_ssids_analyse_coord(ipc_ n, ipc_ *order, longc_ ne, const ipc_ *row,
+void spral_ssids_analyse_coord(ipc_ n, ipc_ *order, int64_t ne, const ipc_ *row,
       const ipc_ *col, const rpc_ *val, void **akeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
 /* Perform numerical factorization */
-void spral_ssids_factor(bool posdef, const longc_ *ptr, const ipc_ *row,
+void spral_ssids_factor(bool posdef, const int64_t *ptr, const ipc_ *row,
       const rpc_ *val, rpc_ *scale, void *akeep, void **fkeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);

--- a/src/dum/C/ssids_ciface.F90
+++ b/src/dum/C/ssids_ciface.F90
@@ -26,7 +26,7 @@
 !  D e r i v e d   t y p e   d e f i n i t i o n s
 !-------------------------------------------------
 
-    TYPE, BIND( C ) :: ssids_options
+    TYPE, BIND( C ) :: spral_ssids_options
        INTEGER ( KIND = ipc_ ) :: print_level
        INTEGER ( KIND = ipc_ ) :: unit_diagnostics
        INTEGER ( KIND = ipc_ ) :: unit_error
@@ -52,9 +52,9 @@
        REAL ( KIND = rpc_ ) :: min_loadbalance
 !    character(len=:), allocatable :: rb_dump
        INTEGER ( KIND = ipc_ ) :: failed_pivot_method
-    END TYPE ssids_options
+    END TYPE spral_ssids_options
 
-    TYPE, BIND( C ) :: ssids_inform
+    TYPE, BIND( C ) :: spral_ssids_inform
        INTEGER ( KIND = ipc_ ) :: flag
        INTEGER ( KIND = ipc_ ) :: matrix_dup
        INTEGER ( KIND = ipc_ ) :: matrix_missing_diag
@@ -77,7 +77,7 @@
        INTEGER ( KIND = ipc_ ) :: nparts
        INTEGER ( KIND = longc_ ) :: cpu_flops
        INTEGER ( KIND = longc_ ) :: gpu_flops
-    END TYPE ssids_inform
+    END TYPE spral_ssids_inform
 
 !----------------------
 !   P r o c e d u r e s
@@ -88,7 +88,7 @@
 !  copy C options parameters to fortran
 
     SUBROUTINE copy_options_in( coptions, foptions )
-    TYPE ( ssids_options ), INTENT( IN ) :: coptions
+    TYPE ( spral_ssids_options ), INTENT( IN ) :: coptions
     TYPE ( f_ssids_options ), INTENT( OUT ) :: foptions
 
     foptions%print_level = coptions%print_level
@@ -122,7 +122,7 @@
 
     SUBROUTINE copy_inform_out( finform, cinform )
     TYPE ( f_ssids_inform ), INTENT( IN ) :: finform
-    TYPE ( ssids_inform ), INTENT( OUT ) :: cinform
+    TYPE ( spral_ssids_inform ), INTENT( OUT ) :: cinform
 
     cinform%flag = finform%flag
     cinform%matrix_dup = finform%matrix_dup

--- a/src/sils/C/sils_ciface.F90
+++ b/src/sils/C/sils_ciface.F90
@@ -34,10 +34,6 @@
 !  D e r i v e d   t y p e   d e f i n i t i o n s
 !-------------------------------------------------
 
-<<<<<<< HEAD
-!   TYPE, BIND( C, name = 'SILS_control_type' ) :: sils_control
-=======
->>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: sils_control_type
       LOGICAL ( KIND = C_BOOL ) :: f_indexing
       INTEGER ( KIND = ipc_ ), DIMENSION( 30 ) :: ICNTL
@@ -67,10 +63,6 @@
       REAL ( KIND = rpc_ ) :: convergence
     END TYPE sils_control_type
 
-<<<<<<< HEAD
-!   TYPE, BIND( C, name = 'SILS_ainfo_type' ) :: SILS_ainfo
-=======
->>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: SILS_ainfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: more
@@ -91,10 +83,6 @@
       REAL ( KIND = rpc_ ) :: opse
     END TYPE SILS_ainfo_type
 
-<<<<<<< HEAD
-!   TYPE, BIND( C, name = 'SILS_finfo_type' ) :: SILS_finfo
-=======
->>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: SILS_finfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: more
@@ -126,10 +114,6 @@
       REAL ( KIND = rpc_ ) :: smax
     END TYPE SILS_finfo_type
 
-<<<<<<< HEAD
-!   TYPE, BIND( C, name = 'SILS_sinfo_type' ) :: SILS_sinfo
-=======
->>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: SILS_sinfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: stat

--- a/src/sils/C/sils_ciface.F90
+++ b/src/sils/C/sils_ciface.F90
@@ -34,10 +34,13 @@
 !  D e r i v e d   t y p e   d e f i n i t i o n s
 !-------------------------------------------------
 
+<<<<<<< HEAD
 !   TYPE, BIND( C, name = 'SILS_control_type' ) :: sils_control
+=======
+>>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: sils_control_type
       LOGICAL ( KIND = C_BOOL ) :: f_indexing
-      INTEGER ( KIND = ipc_ ) :: ICNTL( 30 )
+      INTEGER ( KIND = ipc_ ), DIMENSION( 30 ) :: ICNTL
       INTEGER ( KIND = ipc_ ) :: lp
       INTEGER ( KIND = ipc_ ) :: wp
       INTEGER ( KIND = ipc_ ) :: mp
@@ -54,7 +57,7 @@
       INTEGER ( KIND = ipc_ ) :: thresh
       INTEGER ( KIND = ipc_ ) :: ordering
       INTEGER ( KIND = ipc_ ) :: scaling
-      REAL ( KIND = rpc_ ) :: CNTL( 5 )
+      REAL ( KIND = rpc_ ), DIMENSION( 5 ) :: CNTL
       REAL ( KIND = rpc_ ) :: multiplier
       REAL ( KIND = rpc_ ) :: reduce
       REAL ( KIND = rpc_ ) :: u
@@ -64,7 +67,10 @@
       REAL ( KIND = rpc_ ) :: convergence
     END TYPE sils_control_type
 
+<<<<<<< HEAD
 !   TYPE, BIND( C, name = 'SILS_ainfo_type' ) :: SILS_ainfo
+=======
+>>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: SILS_ainfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: more
@@ -85,7 +91,10 @@
       REAL ( KIND = rpc_ ) :: opse
     END TYPE SILS_ainfo_type
 
+<<<<<<< HEAD
 !   TYPE, BIND( C, name = 'SILS_finfo_type' ) :: SILS_finfo
+=======
+>>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: SILS_finfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: more
@@ -103,7 +112,7 @@
       INTEGER ( KIND = ipc_ ) :: neig
       INTEGER ( KIND = ipc_ ) :: delay
       INTEGER ( KIND = ipc_ ) :: signc
-      INTEGER ( KIND = ipc_ ) :: static
+      INTEGER ( KIND = ipc_ ) :: nstatic
       INTEGER ( KIND = ipc_ ) :: modstep
       INTEGER ( KIND = ipc_ ) :: rank
       INTEGER ( KIND = ipc_ ) :: stat
@@ -117,7 +126,10 @@
       REAL ( KIND = rpc_ ) :: smax
     END TYPE SILS_finfo_type
 
+<<<<<<< HEAD
 !   TYPE, BIND( C, name = 'SILS_sinfo_type' ) :: SILS_sinfo
+=======
+>>>>>>> f3623444 (Fix more headers)
     TYPE, BIND( C ) :: SILS_sinfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: stat
@@ -301,7 +313,7 @@
     ffinfo%neig = cfinfo%neig
     ffinfo%delay = cfinfo%delay
     ffinfo%signc = cfinfo%signc
-    ffinfo%static = cfinfo%static
+    ffinfo%static = cfinfo%nstatic
     ffinfo%modstep = cfinfo%modstep
     ffinfo%rank = cfinfo%rank
     ffinfo%stat = cfinfo%stat
@@ -342,7 +354,7 @@
     cfinfo%neig = ffinfo%neig
     cfinfo%delay = ffinfo%delay
     cfinfo%signc = ffinfo%signc
-    cfinfo%static = ffinfo%static
+    cfinfo%nstatic = ffinfo%static
     cfinfo%modstep = ffinfo%modstep
     cfinfo%rank = ffinfo%rank
     cfinfo%stat = ffinfo%stat


### PR DESCRIPTION
@nimgould @jfowkes 
This PR adds a new CI workflow `headers.yml` that will test at each commit that the C headers are consistent with the structures defined in the Fortran files (`*_ciface.F90`).
Just like the workflows related to macros, symbols and modules, it should help us to develop new packages. 

Jari, I suppose that we should also improve this test to check that the initial structures in Fortran like in `arc.F90` are consistent with the Fortran file `arc_ciface.F90`?

I found the following errors:
```julia
-------------------------------------------------------------
The following structures are only defined in the header files
-------------------------------------------------------------
sils_ainfo_type
icfs_inform_type
icfs_control_type
sils_finfo_type
spral_ssids_inform
trsv_lookup
sils_sinfo_type
trsv_times
spral_ssids_options
icfs_time_type
sils_control_type
-------------------------------------------------------------

-------------------------------------------------------------
-----------------Check errors in structures------------------
-------------------------------------------------------------
The structure sils_ainfo can't be find in an header file.
The structure bnls_subproblem_control_type has missing attributes (50 / 49).
The field 7 of the structure sha_control_type is not consistent (sparse_row / extra_differences).
The field 8 of the structure sha_control_type is not consistent (extra_differences / sparse_row).
The structure sils_sinfo can't be find in an header file.
The field 11 of the structure trb_inform_type is not consistent (factorization_max / factorization_status).
The field 12 of the structure trb_inform_type is not consistent (factorization_status / factorization_max).
The field 9 of the structure arc_inform_type is not consistent (factorization_status / factorization_max).
The field 10 of the structure arc_inform_type is not consistent (factorization_max / factorization_status).
The structure sils_finfo can't be find in an header file.
The structure sils_control can't be find in an header file.
The type of field message of the structure presolve_inform_type is not consistent (char[3] / char[381]).
The structure sls_control_type has missing attributes (51 / 55).
The structure ssids_options can't be find in an header file.
The structure ssids_inform can't be find in an header file.
The field 3 of the structure rpd_inform_type is not consistent (bad_alloc / io_status).
The field 4 of the structure rpd_inform_type is not consistent (io_status / line).
The field 5 of the structure rpd_inform_type is not consistent (line / p_type).
The field 6 of the structure rpd_inform_type is not consistent (p_type / bad_alloc).
The type of field sils_ainfo of the structure sls_inform_type is not consistent (sils_ainfo_type / sils_ainfo).
The type of field sils_finfo of the structure sls_inform_type is not consistent (sils_finfo_type / sils_finfo).
The type of field sils_sinfo of the structure sls_inform_type is not consistent (sils_sinfo_type / sils_sinfo).
The type of field ssids_inform of the structure sls_inform_type is not consistent (spral_ssids_inform / ssids_inform).
-------------------------------------------------------------
```