### PR TITLE
[Meson] Add an option to compile or not the binaries

### DIFF
--- a/.github/meson/action.yml
+++ b/.github/meson/action.yml
@@ -247,6 +247,7 @@ runs:
                              -Dcpp_std=$CPPSTD \
                              -Dexamples=true \
                              -Dtests=true \
+                             -Dbinaries=true \
                              -Dssids=${SSIDS} \
                              -Dpythoniface=${PYTHON_INTERFACE} \
                              -Dint64=${INT64} \

--- a/.github/workflows/symbols.yml
+++ b/.github/workflows/symbols.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Setup GALAHAD
         shell: bash
         run: |
-          meson setup builddir_int32 --buildtype=debug -Dquadruple=true -Dint64=false -Dssids=false -Dexamples=false -Dtests=false -Dlibblas= -Dliblapack=
-          meson setup builddir_int64 --buildtype=debug -Dquadruple=true -Dint64=true -Dssids=false -Dexamples=false -Dtests=false -Dlibblas= -Dliblapack=
+          meson setup builddir_int32 --buildtype=debug -Dquadruple=true -Dint64=false -Dssids=false -Dexamples=false -Dtests=false -Dbinaries=true -Dlibblas= -Dliblapack=
+          meson setup builddir_int64 --buildtype=debug -Dquadruple=true -Dint64=true -Dssids=false -Dexamples=false -Dtests=false -Dbinaries=true -Dlibblas= -Dliblapack=
 
       - name: Build GALAHAD
         shell: bash

--- a/README.meson
+++ b/README.meson
@@ -72,6 +72,7 @@ Currently supported options with their default value:
 * `-Dpythoniface=false`: build the Python interfaces in double precision;
 * `-Dexamples=false`: generate the examples;
 * `-Dtests=false`: generate the tests;
+* `-Dbinaries=false`: generate the binaries;
 * `-Dsingle=true`: generate the single precision library, tests and examples;
 * `-Ddouble=true`: generate the double precision library, tests and examples;
 * `-Dquadruple=false`: generate the quadruple precision library, tests and examples;

--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,7 @@ build_double = get_option('double')
 build_quadruple = get_option('quadruple')
 build_tests = get_option('tests')
 build_examples = get_option('examples')
+build_binaries = get_option('binaries')
 build_ssids = get_option('ssids')
 
 libblas_name = get_option('libblas')
@@ -649,59 +650,61 @@ if build_pythoniface and build_ciface and build_double and (not int64)
 endif
 
 # Binaries
-galahad_binaries_single = galahad_binaries
-galahad_binaries_double = galahad_binaries
-galahad_binaries_quadruple = galahad_binaries
-if libcutest_single.found()
-  galahad_binaries_single += galahad_cutest_binaries
-endif
-if libcutest_double.found()
-  galahad_binaries_double += galahad_cutest_binaries
-endif
-if libcutest_quadruple.found()
-  galahad_binaries_quadruple += galahad_cutest_binaries
-endif
+if build_binaries
+  galahad_binaries_single = galahad_binaries
+  galahad_binaries_double = galahad_binaries
+  galahad_binaries_quadruple = galahad_binaries
+  if libcutest_single.found()
+    galahad_binaries_single += galahad_cutest_binaries
+  endif
+  if libcutest_double.found()
+    galahad_binaries_double += galahad_cutest_binaries
+  endif
+  if libcutest_quadruple.found()
+    galahad_binaries_quadruple += galahad_cutest_binaries
+  endif
 
-if build_single
-  foreach binary: galahad_binaries_single
-    binname = binary[0]
-    binfile = binary[1]
-    executable(binname+'_single', binfile,
-               dependencies : libgalahad_single_deps,
-               fortran_args : pp_flag + extra_args_single,
-               link_with : libgalahad_single,
-               link_language : 'fortran',
-               include_directories: libgalahad_include,
-               install : true)
-  endforeach
-endif
+  if build_single
+    foreach binary: galahad_binaries_single
+      binname = binary[0]
+      binfile = binary[1]
+      executable(binname+'_single', binfile,
+                 dependencies : libgalahad_single_deps,
+                 fortran_args : pp_flag + extra_args_single,
+                 link_with : libgalahad_single,
+                 link_language : 'fortran',
+                 include_directories: libgalahad_include,
+                 install : true)
+    endforeach
+  endif
 
-if build_double
-  foreach binary: galahad_binaries_double
-    binname = binary[0]
-    binfile = binary[1]
-    executable(binname+'_double', binfile,
-               dependencies : libgalahad_double_deps,
-               fortran_args : pp_flag + extra_args_double,
-               link_with : libgalahad_double,
-               link_language : 'fortran',
-               include_directories: libgalahad_include,
-               install : true)
-  endforeach
-endif
+  if build_double
+    foreach binary: galahad_binaries_double
+      binname = binary[0]
+      binfile = binary[1]
+      executable(binname+'_double', binfile,
+                 dependencies : libgalahad_double_deps,
+                 fortran_args : pp_flag + extra_args_double,
+                 link_with : libgalahad_double,
+                 link_language : 'fortran',
+                 include_directories: libgalahad_include,
+                 install : true)
+    endforeach
+  endif
 
-if build_quadruple
-  foreach binary: galahad_binaries_quadruple
-    binname = binary[0]
-    binfile = binary[1]
-    executable(binname+'_quadruple', binfile,
-               dependencies : libgalahad_quadruple_deps,
-               fortran_args : pp_flag + extra_args_quadruple,
-               link_with : libgalahad_quadruple,
-               link_language : 'fortran',
-               include_directories: libgalahad_include,
-               install : true)
-  endforeach
+  if build_quadruple
+    foreach binary: galahad_binaries_quadruple
+      binname = binary[0]
+      binfile = binary[1]
+      executable(binname+'_quadruple', binfile,
+                 dependencies : libgalahad_quadruple_deps,
+                 fortran_args : pp_flag + extra_args_quadruple,
+                 link_with : libgalahad_quadruple,
+                 link_language : 'fortran',
+                 include_directories: libgalahad_include,
+                 install : true)
+    endforeach
+  endif
 endif
 
 # Headers

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,6 +23,11 @@ option('tests',
        value : false,
        description : 'whether to generate the tests')
 
+option('binaries',
+       type : 'boolean',
+       value : false,
+       description : 'whether to generate the binaries')
+
 option('single',
        type : 'boolean',
        value : true,


### PR DESCRIPTION
@jfowkes @nimgould 
I added an option to the Meson build so that the binaries are no longer compiled by default.
I believe the majority of users are not interested in these files, and making their compilation optional seems appropriate from my point of view.

I will wait a green light of you to merge the PR.
![Capture d’écran du 2025-01-03 00-02-50](https://github.com/user-attachments/assets/cfe4cda2-6b4f-4905-80fa-1a2050d7201f)
