### PR TITLE
Add the suffix _type for the C structures in GLS

### DIFF
--- a/GALAHAD.jl/gen/rewriter.jl
+++ b/GALAHAD.jl/gen/rewriter.jl
@@ -27,12 +27,6 @@ function rewrite!(path::String, name::String, optimized::Bool)
     text = replace(text, "real_sp_" => "Float32")
     text = replace(text, "\n    " => "\n  ")
 
-    # Special case for gls
-    text = replace(text, "gls_control" => "gls_control_type")
-    text = replace(text, "gls_ainfo" => "gls_ainfo_type")
-    text = replace(text, "gls_sinfo" => "gls_sinfo_type")
-    text = replace(text, "gls_finfo" => "gls_finfo_type")
-
     for type in types
       for package in packages
         if "$(package)_$(type)_type" ∉ nonparametric_structures

--- a/GALAHAD.jl/src/wrappers/uls.jl
+++ b/GALAHAD.jl/src/wrappers/uls.jl
@@ -48,9 +48,9 @@ struct uls_inform_type{T}
   iterative_refinements::Cint
   alternative::Bool
   solver::NTuple{21,Cchar}
-  gls_ainfo_type::gls_ainfo_type{T}
-  gls_finfo_type::gls_finfo_type{T}
-  gls_sinfo_type::gls_sinfo_type
+  gls_ainfo::gls_ainfo_type{T}
+  gls_finfo::gls_finfo_type{T}
+  gls_sinfo::gls_sinfo_type
   ma48_ainfo::ma48_ainfo{T}
   ma48_finfo::ma48_finfo{T}
   ma48_sinfo::ma48_sinfo

--- a/include/galahad_gls.h
+++ b/include/galahad_gls.h
@@ -124,7 +124,7 @@ extern "C" {
 /**
  * control derived type as a C struct
  */
-struct gls_control {
+struct gls_control_type {
 
     /// \brief
     /// use C or Fortran sparse matrix indexing
@@ -225,7 +225,7 @@ struct gls_control {
 /**
  * ainfo derived type as a C struct
  */
-struct gls_ainfo {
+struct gls_ainfo_type {
 
     /// \brief
     /// Flags success or failure case
@@ -291,7 +291,7 @@ struct gls_ainfo {
 /**
  * finfo derived type as a C struct
  */
-struct gls_finfo {
+struct gls_finfo_type {
 
     /// \brief
     /// Flags success or failure case
@@ -329,7 +329,7 @@ struct gls_finfo {
 /**
  * sinfo derived type as a C struct
  */
-struct gls_sinfo {
+struct gls_sinfo_type {
 
     /// \brief
     /// Flags success or failure case
@@ -348,7 +348,7 @@ struct gls_sinfo {
 // *-*-*-*-*-*-*-*-*-*-    G L S  _ I N I T I A L I Z E    -*-*-*-*-*-*-*-*-*
 
 void gls_initialize( void **data,
-                     struct gls_control *control );
+                     struct gls_control_type *control );
 
 /*!<
  Set default control values and initialize private data
@@ -356,12 +356,12 @@ void gls_initialize( void **data,
   @param[in,out] data  holds private internal data
 
   @param[out] control  is a struct containing control information
-              (see gls_control)
+              (see gls_control_type)
 */
 
 // *-*-*-*-*-*-*-*-*-    G L S  _ R E A D _ S P E C F I L E   -*-*-*-*-*-*-*
 
-void gls_read_specfile( struct gls_control *control,
+void gls_read_specfile( struct gls_control_type *control,
                         const char specfile[] );
 
 /*!<
@@ -373,7 +373,7 @@ void gls_read_specfile( struct gls_control *control,
   $GALAHAD/doc/gls.pdf for a list of keywords that may be set.
 
   @param[in,out]  control  is a struct containing control information
-              (see gls_control)
+              (see gls_control_type)
 
   @param[in]  specfile  is a character string containing the name of
               the specification file
@@ -381,7 +381,7 @@ void gls_read_specfile( struct gls_control *control,
 
 // *-*-*-*-*-*-*-*-*-*-*-*-    G L S  _ I M P O R T   -*-*-*-*-*-*-*-*-*-*
 
-void gls_import( struct gls_control *control,
+void gls_import( struct gls_control_type *control,
                  void **data,
                  ipc_ *status );
 
@@ -389,7 +389,7 @@ void gls_import( struct gls_control *control,
  Import problem data into internal storage prior to solution.
 
  @param[in] control is a struct whose members provide control
-  paramters for the remaining prcedures (see gls_control)
+  paramters for the remaining prcedures (see gls_control_type)
 
  @param[in,out] data holds private internal data
 
@@ -413,7 +413,7 @@ void gls_import( struct gls_control *control,
 
 // *-*-*-*-*-*-*-    G L S  _ R E S E T _ C O N T R O L   -*-*-*-*-*-*-*
 
-void gls_reset_control( struct gls_control *control,
+void gls_reset_control( struct gls_control_type *control,
                         void **data,
                         ipc_ *status );
 
@@ -421,7 +421,7 @@ void gls_reset_control( struct gls_control *control,
  Reset control parameters after import if required.
 
  @param[in] control is a struct whose members provide control
-  paramters for the remaining prcedures (see gls_control)
+  paramters for the remaining prcedures (see gls_control_type)
 
  @param[in,out] data holds private internal data
 
@@ -433,9 +433,9 @@ void gls_reset_control( struct gls_control *control,
 // *-*-*-*-*-*-*-*-*-*-    G L S  _ I N F O R M A T I O N   -*-*-*-*-*-*-*-*
 
 void gls_information( void **data,
-                      struct gls_ainfo *ainfo,
-                      struct gls_finfo *finfo,
-                      struct gls_sinfo *sinfo,
+                      struct gls_ainfo_type *ainfo,
+                      struct gls_finfo_type *finfo,
+                      struct gls_sinfo_type *sinfo,
                       ipc_ *status );
 
 /*!<
@@ -444,13 +444,13 @@ void gls_information( void **data,
   @param[in,out] data  holds private internal data
 
   @param[out] ainfo   is a struct containing analysis output information
-              (see gls_ainfo)
+              (see gls_ainfo_type)
 
   @param[out] finfo   is a struct containing factorization output information
-              (see gls_finfo)
+              (see gls_finfo_type)
 
   @param[out] sinfo   is a struct containing solver output information
-              (see gls_sinfo)
+              (see gls_sinfo_type)
 
   @param[out] status is a scalar variable of type ipc_, that gives
               the exit status from the package.
@@ -461,7 +461,7 @@ void gls_information( void **data,
 // *-*-*-*-*-*-*-*-*-*-    G L S  _ T E R M I N A T E   -*-*-*-*-*-*-*-*-*-*
 
 void gls_finalize( void **data,
-                   struct gls_control *control,
+                   struct gls_control_type *control,
                    ipc_ *status );
 
 /*!<
@@ -470,7 +470,7 @@ void gls_finalize( void **data,
   @param[in,out] data  holds private internal data
 
   @param[out] control  is a struct containing control information
-              (see gls_control)
+              (see gls_control_type)
 
   @param[out] status is a scalar variable of type ipc_, that gives
               the exit status from the package.

--- a/include/galahad_uls.h
+++ b/include/galahad_uls.h
@@ -395,11 +395,11 @@ struct uls_inform_type {
 
     /// \brief
     /// the output arrays from GLS
-    struct gls_ainfo gls_ainfo;
+    struct gls_ainfo_type gls_ainfo;
     /// see gls_ainfo
-    struct gls_finfo gls_finfo;
+    struct gls_finfo_type gls_finfo;
     /// see gls_ainfo
-    struct gls_sinfo gls_sinfo;
+    struct gls_sinfo_type gls_sinfo;
 
     /// \brief
     /// the output arrays from MA48

--- a/src/gls/C/gls_ciface.F90
+++ b/src/gls/C/gls_ciface.F90
@@ -34,7 +34,7 @@
 !  D e r i v e d   t y p e   d e f i n i t i o n s
 !-------------------------------------------------
 
-    TYPE, BIND( C ) :: gls_control
+    TYPE, BIND( C ) :: gls_control_type
       LOGICAL ( KIND = C_BOOL ) :: f_indexing
       INTEGER ( KIND = ipc_ ) :: lp
       INTEGER ( KIND = ipc_ ) :: wp
@@ -58,9 +58,9 @@
       REAL ( KIND = rpc_ ) :: cgce
       LOGICAL ( KIND = C_BOOL ) :: diagonal_pivoting
       LOGICAL ( KIND = C_BOOL ) :: struct_abort
-    END TYPE gls_control
+    END TYPE gls_control_type
 
-    TYPE, BIND( C ) :: GLS_ainfo
+    TYPE, BIND( C ) :: GLS_ainfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: more
       INTEGER ( KIND = ipc_ ) :: len_analyse
@@ -76,9 +76,9 @@
       INTEGER ( KIND = ipc_ ) :: sblock
       INTEGER ( KIND = ipc_ ) :: tblock
       REAL ( KIND = rpc_ ) :: ops
-    END TYPE GLS_ainfo
+    END TYPE GLS_ainfo_type
 
-    TYPE, BIND( C ) :: GLS_finfo
+    TYPE, BIND( C ) :: GLS_finfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: more
       INTEGER ( KIND = ipc_ ) :: size_factor
@@ -87,13 +87,13 @@
       INTEGER ( KIND = ipc_ ) :: rank
       INTEGER ( KIND = ipc_ ) :: stat
       REAL ( KIND = rpc_ ) :: ops
-    END TYPE GLS_finfo
+    END TYPE GLS_finfo_type
 
-    TYPE, BIND( C ) :: GLS_sinfo
+    TYPE, BIND( C ) :: GLS_sinfo_type
       INTEGER ( KIND = ipc_ ) :: flag
       INTEGER ( KIND = ipc_ ) :: more
       INTEGER ( KIND = ipc_ ) :: stat
-    END TYPE GLS_sinfo
+    END TYPE GLS_sinfo_type
 
 !----------------------
 !   P r o c e d u r e s
@@ -104,7 +104,7 @@
 !  copy C control parameters to fortran
 
     SUBROUTINE copy_control_in( ccontrol, fcontrol, f_indexing )
-    TYPE ( gls_control ), INTENT( IN ) :: ccontrol
+    TYPE ( gls_control_type ), INTENT( IN ) :: ccontrol
     TYPE ( f_gls_control ), INTENT( OUT ) :: fcontrol
     LOGICAL, OPTIONAL, INTENT( OUT ) :: f_indexing
 
@@ -146,7 +146,7 @@
 
     SUBROUTINE copy_control_out( fcontrol, ccontrol, f_indexing )
     TYPE ( f_gls_control ), INTENT( IN ) :: fcontrol
-    TYPE ( gls_control ), INTENT( OUT ) :: ccontrol
+    TYPE ( gls_control_type ), INTENT( OUT ) :: ccontrol
     LOGICAL, OPTIONAL, INTENT( IN ) :: f_indexing
 
     ! C or Fortran sparse matrix indexing
@@ -186,7 +186,7 @@
 !  copy C ainfo parameters to fortran
 
     SUBROUTINE copy_ainfo_in( cainfo, fainfo )
-    TYPE ( gls_ainfo ), INTENT( IN ) :: cainfo
+    TYPE ( gls_ainfo_type ), INTENT( IN ) :: cainfo
     TYPE ( f_gls_ainfo ), INTENT( OUT ) :: fainfo
 
     ! Integers
@@ -216,7 +216,7 @@
 
     SUBROUTINE copy_ainfo_out( fainfo, cainfo )
     TYPE ( f_gls_ainfo ), INTENT( IN ) :: fainfo
-    TYPE ( gls_ainfo ), INTENT( OUT ) :: cainfo
+    TYPE ( gls_ainfo_type ), INTENT( OUT ) :: cainfo
 
     ! Integers
     cainfo%flag = fainfo%flag
@@ -244,7 +244,7 @@
 !  copy C finfo parameters to fortran
 
     SUBROUTINE copy_finfo_in( cfinfo, ffinfo )
-    TYPE ( gls_finfo ), INTENT( IN ) :: cfinfo
+    TYPE ( gls_finfo_type ), INTENT( IN ) :: cfinfo
     TYPE ( f_gls_finfo ), INTENT( OUT ) :: ffinfo
 
     ! Integers
@@ -267,7 +267,7 @@
 
     SUBROUTINE copy_finfo_out( ffinfo, cfinfo )
     TYPE ( f_gls_finfo ), INTENT( IN ) :: ffinfo
-    TYPE ( gls_finfo ), INTENT( OUT ) :: cfinfo
+    TYPE ( gls_finfo_type ), INTENT( OUT ) :: cfinfo
 
     ! Integers
     cfinfo%flag = ffinfo%flag
@@ -288,7 +288,7 @@
 !  copy C sinfo parameters to fortran
 
     SUBROUTINE copy_sinfo_in( csinfo, fsinfo )
-    TYPE ( gls_sinfo ), INTENT( IN ) :: csinfo
+    TYPE ( gls_sinfo_type ), INTENT( IN ) :: csinfo
     TYPE ( f_gls_sinfo ), INTENT( OUT ) :: fsinfo
 
     ! Integers
@@ -304,7 +304,7 @@
 
     SUBROUTINE copy_sinfo_out( fsinfo, csinfo )
     TYPE ( f_gls_sinfo ), INTENT( IN ) :: fsinfo
-    TYPE ( gls_sinfo ), INTENT( OUT ) :: csinfo
+    TYPE ( gls_sinfo_type ), INTENT( OUT ) :: csinfo
 
     ! Integers
     csinfo%flag = fsinfo%flag
@@ -328,7 +328,7 @@
 !  dummy arguments
 
   TYPE ( C_PTR ), INTENT( OUT ) :: cdata ! data is a black-box
-  TYPE ( gls_control ), INTENT( OUT ) :: ccontrol
+  TYPE ( gls_control_type ), INTENT( OUT ) :: ccontrol
 
 !  local variables
 
@@ -367,7 +367,7 @@
 !  dummy arguments
 
   INTEGER ( KIND = ipc_ ), INTENT( OUT ) :: status
-  TYPE ( gls_control ), INTENT( INOUT ) :: ccontrol
+  TYPE ( gls_control_type ), INTENT( INOUT ) :: ccontrol
   TYPE ( C_PTR ), INTENT( INOUT ) :: cdata
 
 !  local variables
@@ -406,9 +406,9 @@
 !  dummy arguments
 
   TYPE ( C_PTR ), INTENT( INOUT ) :: cdata
-  TYPE ( gls_ainfo ), INTENT( INOUT ) :: cainfo
-  TYPE ( gls_finfo ), INTENT( INOUT ) :: cfinfo
-  TYPE ( gls_sinfo ), INTENT( INOUT ) :: csinfo
+  TYPE ( gls_ainfo_type ), INTENT( INOUT ) :: cainfo
+  TYPE ( gls_finfo_type ), INTENT( INOUT ) :: cfinfo
+  TYPE ( gls_sinfo_type ), INTENT( INOUT ) :: csinfo
   INTEGER ( KIND = ipc_ ), INTENT( OUT ) :: status
 
 !  local variables
@@ -446,7 +446,7 @@
 !  dummy arguments
 
   TYPE ( C_PTR ), INTENT( INOUT ) :: cdata
-  TYPE ( gls_control ), INTENT( IN ) :: ccontrol
+  TYPE ( gls_control_type ), INTENT( IN ) :: ccontrol
   INTEGER ( KIND = ipc_ ), INTENT( OUT ) :: status
 
 !  local variables

--- a/src/gls/Python/gls_pyiface.c
+++ b/src/gls/Python/gls_pyiface.c
@@ -19,19 +19,19 @@
 #include "galahad_gls.h"
 
 /* Module global variables */
-static void *data;                  // private internal data
-static struct gls_control control;  // control struct
-static struct gls_ainfo ainfo;      // ainfo struct
-static struct gls_finfo finfo;      // ainfo struct
-static struct gls_sinfo sinfo;      // ainfo struct
-static bool init_called = false;    // record if initialise was called
-static int status = 0;              // exit status
+static void *data;                       // private internal data
+static struct gls_control_type control;  // control struct
+static struct gls_ainfo_type ainfo;      // ainfo struct
+static struct gls_finfo_type finfo;      // ainfo struct
+static struct gls_sinfo_type sinfo;      // ainfo struct
+static bool init_called = false;         // record if initialise was called
+static int status = 0;                   // exit status
 
 //  *-*-*-*-*-*-*-*-*-*-   UPDATE CONTROL    -*-*-*-*-*-*-*-*-*-*
 
 /* Update the control options: use C defaults but update any passed via Python*/
 // NB not static as it is used for nested control within SBLS Python interface
-bool gls_update_control(struct gls_control *control,
+bool gls_update_control(struct gls_control_type *control,
                                PyObject *py_options){
 
     // Use C defaults if Python options not passed
@@ -194,7 +194,7 @@ bool gls_update_control(struct gls_control *control,
 
 /* Take the control struct from C and turn it into a python options dict */
 // NB not static as it is used for nested inform within SBLS Python interface
-PyObject* gls_make_options_dict(const struct gls_control *control){
+PyObject* gls_make_options_dict(const struct gls_control_type *control){
     PyObject *py_options = PyDict_New();
 
     PyDict_SetItemString(py_options, "lp",
@@ -259,7 +259,7 @@ PyObject* gls_make_options_dict(const struct gls_control *control){
 
 /* Take the ainfo struct from C and turn it into a python dictionary */
 // NB not static as it is used for nested control within SLS Python interface
-PyObject* gls_make_ainfo_dict(const struct gls_ainfo *ainfo){
+PyObject* gls_make_ainfo_dict(const struct gls_ainfo_type *ainfo){
     PyObject *py_ainfo = PyDict_New();
 
     PyDict_SetItemString(py_ainfo, "flag",
@@ -300,7 +300,7 @@ PyObject* gls_make_ainfo_dict(const struct gls_ainfo *ainfo){
 
 /* Take the finfo struct from C and turn it into a python dictionary */
 // NB not static as it is used for nested control within SLS Python interface
-PyObject* gls_make_finfo_dict(const struct gls_finfo *finfo){
+PyObject* gls_make_finfo_dict(const struct gls_finfo_type *finfo){
     PyObject *py_finfo = PyDict_New();
 
     PyDict_SetItemString(py_finfo, "flag",
@@ -327,7 +327,7 @@ PyObject* gls_make_finfo_dict(const struct gls_finfo *finfo){
 
 /* Take the sinfo struct from C and turn it into a python dictionary */
 // NB not static as it is used for nested control within SLS Python interface
-PyObject* gls_make_sinfo_dict(const struct gls_sinfo *sinfo){
+PyObject* gls_make_sinfo_dict(const struct gls_sinfo_type *sinfo){
     PyObject *py_sinfo = PyDict_New();
 
     PyDict_SetItemString(py_sinfo, "flag",

--- a/src/uls/C/uls_ciface.F90
+++ b/src/uls/C/uls_ciface.F90
@@ -30,10 +30,10 @@
         f_uls_terminate => ULS_terminate
 
     USE GALAHAD_GLS_precision_ciface, ONLY:                                    &
-        gls_control,                                                           &
-        gls_ainfo,                                                             &
-        gls_finfo,                                                             &
-        gls_sinfo,                                                             &
+        gls_control_type,                                                      &
+        gls_ainfo_type,                                                        &
+        gls_finfo_type,                                                        &
+        gls_sinfo_type,                                                        &
         copy_gls_ainfo_in => copy_ainfo_in,                                    &
         copy_gls_finfo_in => copy_finfo_in,                                    &
         copy_gls_sinfo_in => copy_sinfo_in,                                    &
@@ -102,9 +102,9 @@
       INTEGER ( KIND = ipc_ ) :: iterative_refinements
       LOGICAL ( KIND = C_BOOL ) :: alternative
       CHARACTER ( KIND = C_CHAR ), DIMENSION( 21 ) :: solver
-      TYPE ( gls_ainfo ) :: gls_ainfo
-      TYPE ( gls_finfo ) :: gls_finfo
-      TYPE ( gls_sinfo ) :: gls_sinfo
+      TYPE ( gls_ainfo_type ) :: gls_ainfo
+      TYPE ( gls_finfo_type ) :: gls_finfo
+      TYPE ( gls_sinfo_type ) :: gls_sinfo
       TYPE ( ma48_ainfo ) :: ma48_ainfo
       TYPE ( ma48_finfo ) :: ma48_finfo
       TYPE ( ma48_sinfo ) :: ma48_sinfo

--- a/src/uls/Python/uls_pyiface.c
+++ b/src/uls/Python/uls_pyiface.c
@@ -19,9 +19,9 @@
 #include "galahad_uls.h"
 
 /* Nested HSL info/inform prototypes */
-PyObject* gls_make_ainfo_dict(const struct gls_ainfo *ainfo);
-PyObject* gls_make_finfo_dict(const struct gls_finfo *finfo);
-PyObject* gls_make_sinfo_dict(const struct gls_sinfo *sinfo);
+PyObject* gls_make_ainfo_dict(const struct gls_ainfo_type *ainfo);
+PyObject* gls_make_finfo_dict(const struct gls_finfo_type *finfo);
+PyObject* gls_make_sinfo_dict(const struct gls_sinfo_type *sinfo);
 //PyObject* ma48_make_ainfo_dict(const struct ma48_ainfo_type *ainfo);
 //PyObject* ma48_make_finfo_dict(const struct ma48_finfo_type *finfo);
 //PyObject* ma48_make_sinfo_dict(const struct ma48_sinfo_type *sinfo);


### PR DESCRIPTION
@nimgould Is it fine for you?
It doesn't concern the code in Fortran, it's just the structures in the C interface that are renamed.
I always need some sed commands in the Julia interface because of this missing suffix.
Only `GLS` is concerned by this "issue".