### PR TITLE
Add galahad_load_routines and galahad_unload_routines

### DIFF
--- a/src/cutest_functions/cutest_trampoline.F90
+++ b/src/cutest_functions/cutest_trampoline.F90
@@ -1,0 +1,28 @@
+! THIS VERSION: GALAHAD 5.2 - 2025-04-17 AT 16:20 GMT.
+
+#ifdef REAL_32
+#define GALAHAD_LOAD_ROUTINES_NAME galahad_load_routines_s
+#define GALAHAD_UNLOAD_ROUTINES_NAME galahad_unload_routines_s
+#define CUTEST_LOAD_ROUTINES_NAME cutest_load_routines_s
+#define CUTEST_UNLOAD_ROUTINES_NAME cutest_unload_routines_s
+#elif REAL_128
+#define GALAHAD_LOAD_ROUTINES_NAME galahad_load_routines_q
+#define GALAHAD_UNLOAD_ROUTINES_NAME galahad_unload_routines_q
+#define CUTEST_LOAD_ROUTINES_NAME cutest_load_routines_q
+#define CUTEST_UNLOAD_ROUTINES_NAME cutest_unload_routines_q
+#else
+#define GALAHAD_LOAD_ROUTINES_NAME galahad_load_routines
+#define GALAHAD_UNLOAD_ROUTINES_NAME galahad_unload_routines
+#define CUTEST_LOAD_ROUTINES_NAME cutest_load_routines
+#define CUTEST_UNLOAD_ROUTINES_NAME cutest_unload_routines
+#endif
+
+SUBROUTINE GALAHAD_LOAD_ROUTINES_NAME(libname)
+    USE ISO_C_BINDING, ONLY : C_CHAR
+    CHARACTER ( KIND = C_CHAR ), DIMENSION( * ), INTENT( IN ) :: libname
+    CALL CUTEST_LOAD_ROUTINES_NAME(libname)
+END SUBROUTINE GALAHAD_LOAD_ROUTINES_NAME
+
+SUBROUTINE GALAHAD_UNLOAD_ROUTINES_NAME()
+    CALL CUTEST_UNLOAD_ROUTINES_NAME()
+END SUBROUTINE GALAHAD_UNLOAD_ROUTINES_NAME

--- a/src/cutest_functions/meson.build
+++ b/src/cutest_functions/meson.build
@@ -1,1 +1,1 @@
-libgalahad_cutest_src += files('cutest_functions.F90')
+libgalahad_cutest_src += files('cutest_functions.F90', 'cutest_trampoline.F90')


### PR DESCRIPTION
As discussed this morning with @nimgould 

Users can now use the exported symbols `galahad_load_routines_r` and`galahad_unload_routines_r` to load / unload the shared libraries of the decoded SIF problems.

Relevant for all files `run*.F90`.

```shell
alexis@HP-Spectre:~/Bureau/git/GALAHAD/builddir$ nm -D libgalahad_double.so | grep load_routines
                 U cutest_load_routines_
                 U cutest_unload_routines_
00000000028118d1 T galahad_load_routines_
00000000028118f5 T galahad_unload_routines_

alexis@HP-Spectre:~/Bureau/git/GALAHAD/builddir$ nm -D libgalahad_single.so | grep load_routines
                 U cutest_load_routines_s_
                 U cutest_unload_routines_s_
0000000002806491 T galahad_load_routines_s_
00000000028064b5 T galahad_unload_routines_s_

alexis@HP-Spectre:~/Bureau/git/GALAHAD/builddir$ nm -D libgalahad_quadruple.so | grep load_routines
                 U cutest_load_routines_q_
                 U cutest_unload_routines_q_
0000000002952b62 T galahad_load_routines_q_
0000000002952b86 T galahad_unload_routines_q_
```