### PR TITLE
Support the binaries for QPLIB in GALAHAD.jl

### DIFF
--- a/GALAHAD.jl/gen/wrapper.jl
+++ b/GALAHAD.jl/gen/wrapper.jl
@@ -19,7 +19,9 @@ function run_qplib_wrapper(name::String, precision::String)
 str = "const run$(name)_qplib_$(precision) = joinpath(galahad_bindir, \"run$(name)_qplib_$(precision)\$(exeext)\")
 
 function run_qplib(::Val{:$name}, ::Val{:$precision}, path_qplib::String)
-  run(`\$run$(name)_qplib_$precision \$path_qplib`)
+  open(path_qplib, \"r\") do io
+    run(`\$run$(name)_qplib_$precision`, stdin = io)
+  end
 end
 "
 return str

--- a/GALAHAD.jl/src/wrappers/bqp.jl
+++ b/GALAHAD.jl/src/wrappers/bqp.jl
@@ -553,17 +553,23 @@ end
 const runbqp_qplib_single = joinpath(galahad_bindir, "runbqp_qplib_single$(exeext)")
 
 function run_qplib(::Val{:bqp}, ::Val{:single}, path_qplib::String)
-  return run(`$runbqp_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runbqp_qplib_single`; stdin=io)
+  end
 end
 
 const runbqp_qplib_double = joinpath(galahad_bindir, "runbqp_qplib_double$(exeext)")
 
 function run_qplib(::Val{:bqp}, ::Val{:double}, path_qplib::String)
-  return run(`$runbqp_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runbqp_qplib_double`; stdin=io)
+  end
 end
 
 const runbqp_qplib_quadruple = joinpath(galahad_bindir, "runbqp_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:bqp}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runbqp_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runbqp_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/bqpb.jl
+++ b/GALAHAD.jl/src/wrappers/bqpb.jl
@@ -524,17 +524,23 @@ end
 const runbqpb_qplib_single = joinpath(galahad_bindir, "runbqpb_qplib_single$(exeext)")
 
 function run_qplib(::Val{:bqpb}, ::Val{:single}, path_qplib::String)
-  return run(`$runbqpb_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runbqpb_qplib_single`; stdin=io)
+  end
 end
 
 const runbqpb_qplib_double = joinpath(galahad_bindir, "runbqpb_qplib_double$(exeext)")
 
 function run_qplib(::Val{:bqpb}, ::Val{:double}, path_qplib::String)
-  return run(`$runbqpb_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runbqpb_qplib_double`; stdin=io)
+  end
 end
 
 const runbqpb_qplib_quadruple = joinpath(galahad_bindir, "runbqpb_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:bqpb}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runbqpb_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runbqpb_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/ccqp.jl
+++ b/GALAHAD.jl/src/wrappers/ccqp.jl
@@ -585,17 +585,23 @@ end
 const runccqp_qplib_single = joinpath(galahad_bindir, "runccqp_qplib_single$(exeext)")
 
 function run_qplib(::Val{:ccqp}, ::Val{:single}, path_qplib::String)
-  return run(`$runccqp_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runccqp_qplib_single`; stdin=io)
+  end
 end
 
 const runccqp_qplib_double = joinpath(galahad_bindir, "runccqp_qplib_double$(exeext)")
 
 function run_qplib(::Val{:ccqp}, ::Val{:double}, path_qplib::String)
-  return run(`$runccqp_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runccqp_qplib_double`; stdin=io)
+  end
 end
 
 const runccqp_qplib_quadruple = joinpath(galahad_bindir, "runccqp_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:ccqp}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runccqp_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runccqp_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/cdqp.jl
+++ b/GALAHAD.jl/src/wrappers/cdqp.jl
@@ -19,17 +19,23 @@ end
 const runcdqp_qplib_single = joinpath(galahad_bindir, "runcdqp_qplib_single$(exeext)")
 
 function run_qplib(::Val{:cdqp}, ::Val{:single}, path_qplib::String)
-  return run(`$runcdqp_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runcdqp_qplib_single`; stdin=io)
+  end
 end
 
 const runcdqp_qplib_double = joinpath(galahad_bindir, "runcdqp_qplib_double$(exeext)")
 
 function run_qplib(::Val{:cdqp}, ::Val{:double}, path_qplib::String)
-  return run(`$runcdqp_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runcdqp_qplib_double`; stdin=io)
+  end
 end
 
 const runcdqp_qplib_quadruple = joinpath(galahad_bindir, "runcdqp_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:cdqp}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runcdqp_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runcdqp_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/cqp.jl
+++ b/GALAHAD.jl/src/wrappers/cqp.jl
@@ -579,17 +579,23 @@ end
 const runcqp_qplib_single = joinpath(galahad_bindir, "runcqp_qplib_single$(exeext)")
 
 function run_qplib(::Val{:cqp}, ::Val{:single}, path_qplib::String)
-  return run(`$runcqp_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runcqp_qplib_single`; stdin=io)
+  end
 end
 
 const runcqp_qplib_double = joinpath(galahad_bindir, "runcqp_qplib_double$(exeext)")
 
 function run_qplib(::Val{:cqp}, ::Val{:double}, path_qplib::String)
-  return run(`$runcqp_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runcqp_qplib_double`; stdin=io)
+  end
 end
 
 const runcqp_qplib_quadruple = joinpath(galahad_bindir, "runcqp_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:cqp}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runcqp_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runcqp_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/dlp.jl
+++ b/GALAHAD.jl/src/wrappers/dlp.jl
@@ -19,17 +19,23 @@ end
 const rundlp_qplib_single = joinpath(galahad_bindir, "rundlp_qplib_single$(exeext)")
 
 function run_qplib(::Val{:dlp}, ::Val{:single}, path_qplib::String)
-  return run(`$rundlp_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$rundlp_qplib_single`; stdin=io)
+  end
 end
 
 const rundlp_qplib_double = joinpath(galahad_bindir, "rundlp_qplib_double$(exeext)")
 
 function run_qplib(::Val{:dlp}, ::Val{:double}, path_qplib::String)
-  return run(`$rundlp_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$rundlp_qplib_double`; stdin=io)
+  end
 end
 
 const rundlp_qplib_quadruple = joinpath(galahad_bindir, "rundlp_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:dlp}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$rundlp_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$rundlp_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/dqp.jl
+++ b/GALAHAD.jl/src/wrappers/dqp.jl
@@ -573,17 +573,23 @@ end
 const rundqp_qplib_single = joinpath(galahad_bindir, "rundqp_qplib_single$(exeext)")
 
 function run_qplib(::Val{:dqp}, ::Val{:single}, path_qplib::String)
-  return run(`$rundqp_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$rundqp_qplib_single`; stdin=io)
+  end
 end
 
 const rundqp_qplib_double = joinpath(galahad_bindir, "rundqp_qplib_double$(exeext)")
 
 function run_qplib(::Val{:dqp}, ::Val{:double}, path_qplib::String)
-  return run(`$rundqp_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$rundqp_qplib_double`; stdin=io)
+  end
 end
 
 const rundqp_qplib_quadruple = joinpath(galahad_bindir, "rundqp_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:dqp}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$rundqp_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$rundqp_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/lpa.jl
+++ b/GALAHAD.jl/src/wrappers/lpa.jl
@@ -426,17 +426,23 @@ end
 const runlpa_qplib_single = joinpath(galahad_bindir, "runlpa_qplib_single$(exeext)")
 
 function run_qplib(::Val{:lpa}, ::Val{:single}, path_qplib::String)
-  return run(`$runlpa_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runlpa_qplib_single`; stdin=io)
+  end
 end
 
 const runlpa_qplib_double = joinpath(galahad_bindir, "runlpa_qplib_double$(exeext)")
 
 function run_qplib(::Val{:lpa}, ::Val{:double}, path_qplib::String)
-  return run(`$runlpa_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runlpa_qplib_double`; stdin=io)
+  end
 end
 
 const runlpa_qplib_quadruple = joinpath(galahad_bindir, "runlpa_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:lpa}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runlpa_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runlpa_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/lpb.jl
+++ b/GALAHAD.jl/src/wrappers/lpb.jl
@@ -476,17 +476,23 @@ end
 const runlpb_qplib_single = joinpath(galahad_bindir, "runlpb_qplib_single$(exeext)")
 
 function run_qplib(::Val{:lpb}, ::Val{:single}, path_qplib::String)
-  return run(`$runlpb_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runlpb_qplib_single`; stdin=io)
+  end
 end
 
 const runlpb_qplib_double = joinpath(galahad_bindir, "runlpb_qplib_double$(exeext)")
 
 function run_qplib(::Val{:lpb}, ::Val{:double}, path_qplib::String)
-  return run(`$runlpb_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runlpb_qplib_double`; stdin=io)
+  end
 end
 
 const runlpb_qplib_quadruple = joinpath(galahad_bindir, "runlpb_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:lpb}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runlpb_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runlpb_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/qp.jl
+++ b/GALAHAD.jl/src/wrappers/qp.jl
@@ -19,17 +19,23 @@ end
 const runqp_qplib_single = joinpath(galahad_bindir, "runqp_qplib_single$(exeext)")
 
 function run_qplib(::Val{:qp}, ::Val{:single}, path_qplib::String)
-  return run(`$runqp_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqp_qplib_single`; stdin=io)
+  end
 end
 
 const runqp_qplib_double = joinpath(galahad_bindir, "runqp_qplib_double$(exeext)")
 
 function run_qplib(::Val{:qp}, ::Val{:double}, path_qplib::String)
-  return run(`$runqp_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqp_qplib_double`; stdin=io)
+  end
 end
 
 const runqp_qplib_quadruple = joinpath(galahad_bindir, "runqp_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:qp}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runqp_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqp_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/qpa.jl
+++ b/GALAHAD.jl/src/wrappers/qpa.jl
@@ -660,17 +660,23 @@ end
 const runqpa_qplib_single = joinpath(galahad_bindir, "runqpa_qplib_single$(exeext)")
 
 function run_qplib(::Val{:qpa}, ::Val{:single}, path_qplib::String)
-  return run(`$runqpa_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpa_qplib_single`; stdin=io)
+  end
 end
 
 const runqpa_qplib_double = joinpath(galahad_bindir, "runqpa_qplib_double$(exeext)")
 
 function run_qplib(::Val{:qpa}, ::Val{:double}, path_qplib::String)
-  return run(`$runqpa_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpa_qplib_double`; stdin=io)
+  end
 end
 
 const runqpa_qplib_quadruple = joinpath(galahad_bindir, "runqpa_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:qpa}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runqpa_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpa_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/qpb.jl
+++ b/GALAHAD.jl/src/wrappers/qpb.jl
@@ -501,17 +501,23 @@ end
 const runqpb_qplib_single = joinpath(galahad_bindir, "runqpb_qplib_single$(exeext)")
 
 function run_qplib(::Val{:qpb}, ::Val{:single}, path_qplib::String)
-  return run(`$runqpb_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpb_qplib_single`; stdin=io)
+  end
 end
 
 const runqpb_qplib_double = joinpath(galahad_bindir, "runqpb_qplib_double$(exeext)")
 
 function run_qplib(::Val{:qpb}, ::Val{:double}, path_qplib::String)
-  return run(`$runqpb_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpb_qplib_double`; stdin=io)
+  end
 end
 
 const runqpb_qplib_quadruple = joinpath(galahad_bindir, "runqpb_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:qpb}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runqpb_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpb_qplib_quadruple`; stdin=io)
+  end
 end

--- a/GALAHAD.jl/src/wrappers/qpc.jl
+++ b/GALAHAD.jl/src/wrappers/qpc.jl
@@ -19,17 +19,23 @@ end
 const runqpc_qplib_single = joinpath(galahad_bindir, "runqpc_qplib_single$(exeext)")
 
 function run_qplib(::Val{:qpc}, ::Val{:single}, path_qplib::String)
-  return run(`$runqpc_qplib_single $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpc_qplib_single`; stdin=io)
+  end
 end
 
 const runqpc_qplib_double = joinpath(galahad_bindir, "runqpc_qplib_double$(exeext)")
 
 function run_qplib(::Val{:qpc}, ::Val{:double}, path_qplib::String)
-  return run(`$runqpc_qplib_double $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpc_qplib_double`; stdin=io)
+  end
 end
 
 const runqpc_qplib_quadruple = joinpath(galahad_bindir, "runqpc_qplib_quadruple$(exeext)")
 
 function run_qplib(::Val{:qpc}, ::Val{:quadruple}, path_qplib::String)
-  return run(`$runqpc_qplib_quadruple $path_qplib`)
+  open(path_qplib, "r") do io
+    return run(`$runqpc_qplib_quadruple`; stdin=io)
+  end
 end


### PR DESCRIPTION
@nimgould How does QPLIB support work in single and quadruple precision? 
Does GALAHAD read the data in double precision and then perform the conversion?

Can you also confirm that the correct way to call a binary for QPLIB is:
```shell
runbpq_qplib_double < myfile.qplib
````
