### PR TITLE
Automatically build Python wheels on Windows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Note: builds on these are backward compatible
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -53,11 +53,11 @@ jobs:
 
           # cibuildwheel doesn't yet ship a default repair command for Windows
           CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --ignore-existing -w {dest_dir} {wheel}"
 
           # test built wheels
           CIBW_TEST_REQUIRES: numpy
-          CIBW_TEST_COMMAND: python -c 'from galahad import ugo; options = ugo.initialize(); ugo.terminate()'
+          CIBW_TEST_COMMAND: python -c "from galahad import ugo; options = ugo.initialize(); ugo.terminate()"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/meson.build
+++ b/meson.build
@@ -649,8 +649,10 @@ if build_pythoniface and build_ciface and build_double and (not int64)
     check : true
   ).stdout().strip()
 
-  # install python metadata
-  install_data(files('doc/PYTHON_METADATA'), install_dir : join_paths(py.get_install_dir(),'galahad-'+meson.project_version()+'.dist-info'))
+  # patch PATH on windows to allow libgalahad_double.dll to be found
+  py.install_sources('src/__init__.py',
+                     subdir : 'galahad',
+                     pure: false)
 
   # compile and install python interfaces
   foreach interface: libgalahad_python_src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 build-backend = 'mesonpy'
 requires = ['meson-python', 'numpy']
 
+[tool.meson-python]
+allow-windows-internal-shared-libs = true
+
 [tool.meson-python.args]
 setup = ['-Dpythoniface=true', '-Dpython.install_env=auto', '-Dsingle=false', '-Dtests=false']
 install = ['--tags=runtime,python-runtime']

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2024 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+
+def _append_to_sharedlib_load_path():
+    """Ensure the shared libraries in this package can be loaded on Windows.
+
+    Windows lacks a concept equivalent to RPATH: Python extension modules
+    cannot find DLLs installed outside the DLL search path. This function
+    ensures that the location of the shared libraries distributed inside this
+    Python package is in the DLL search path of the process.
+
+    The Windows DLL search path includes the path to the object attempting
+    to load the DLL: it needs to be augmented only when the Python extension
+    modules and the DLLs they require are installed in separate directories.
+    Cygwin does not have the same default library search path: all locations
+    where the shared libraries are installed need to be added to the search
+    path.
+
+    This function is very similar to the snippet inserted into the main
+    ``__init__.py`` of a package by ``delvewheel`` when it vendors external
+    shared libraries.
+
+    .. note::
+
+        `os.add_dll_directory` is only available for Python 3.8 and later, and
+        in the Conda ``python`` packages it works as advertised only for
+        version 3.10 and later. For older Python versions, pre-loading the DLLs
+        with `ctypes.WinDLL` may be preferred.
+    """
+    basedir = os.path.dirname(__file__)
+    subdir = os.path.join(basedir, '..', '.galahad_optrove.mesonpy.libs')
+    if os.name == 'nt':
+        os.add_dll_directory(subdir)
+    elif sys.platform == 'cygwin':
+        os.environ['PATH'] = os.pathsep.join((os.environ['PATH'], basedir, subdir))
+
+
+_append_to_sharedlib_load_path()


### PR DESCRIPTION
Finally with some nasty DLL hacking on Windows we can automatically precompile Python binaries on Windows.