### PR TITLE
Update galahad_sls_defaults_dls.h

### DIFF
--- a/include/galahad_sls_defaults_dls.h
+++ b/include/galahad_sls_defaults_dls.h
@@ -1,1 +1,1 @@
-    CHARACTER ( len = 5 ) :: definite_linear_solver = 'sytr '
+    CHARACTER ( len = 5 ) :: definite_linear_solver = 'potr '


### PR DESCRIPTION
It is more relevant to test with `potr` than `sytr` if the linear system is SPD.