### PR TITLE
Add a header galahad_callbacks.h

### DIFF
--- a/GALAHAD.jl/gen/rewriter.jl
+++ b/GALAHAD.jl/gen/rewriter.jl
@@ -78,6 +78,14 @@ function rewrite!(path::String, name::String, optimized::Bool)
       end
     end
 
+    # Callbacks
+    for callback in ("galahad_f", "galahad_g", "galahad_h", "galahad_prec", "galahad_hprod",
+                     "galahad_shprod", "galahad_constant_prec", "galahad_r", "galahad_jr",
+                     "galahad_hr", "galahad_jrprod", "galahad_hrprod", "galahad_shrprod",
+                     "galahad_fc", "galahad_gj", "galahad_hl", "galahad_fgh")
+      text = replace(text, "::Ptr{$(callback)}" => "::Ptr{Cvoid}")
+    end
+
     # SSIDS
     text = replace(text, "::spral_ssids_options" => "::spral_ssids_options{T,INT}")
     text = replace(text, "::spral_ssids_inform" => "::spral_ssids_inform{T,INT}")

--- a/GALAHAD.jl/src/wrappers/nls.jl
+++ b/GALAHAD.jl/src/wrappers/nls.jl
@@ -410,149 +410,157 @@ end
 export nls_solve_with_mat
 
 function nls_solve_with_mat(::Type{Float32}, ::Type{Int32}, data, userdata, status, n, m, x,
-                            c, g, eval_c, j_ne, eval_j, h_ne, eval_h, p_ne, eval_hprods)
+                            c, g, eval_r, j_ne, eval_jr, h_ne, eval_hr, p_ne, eval_shrprod)
   @ccall libgalahad_single.nls_solve_with_mat(data::Ptr{Ptr{Cvoid}}, userdata::Ptr{Cvoid},
                                               status::Ptr{Int32}, n::Int32, m::Int32,
                                               x::Ptr{Float32}, c::Ptr{Float32},
-                                              g::Ptr{Float32}, eval_c::Ptr{Cvoid},
-                                              j_ne::Int32, eval_j::Ptr{Cvoid}, h_ne::Int32,
-                                              eval_h::Ptr{Cvoid}, p_ne::Int32,
-                                              eval_hprods::Ptr{Cvoid})::Cvoid
+                                              g::Ptr{Float32}, eval_r::Ptr{Cvoid},
+                                              j_ne::Int32, eval_jr::Ptr{Cvoid}, h_ne::Int32,
+                                              eval_hr::Ptr{Cvoid}, p_ne::Int32,
+                                              eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_with_mat(::Type{Float32}, ::Type{Int64}, data, userdata, status, n, m, x,
-                            c, g, eval_c, j_ne, eval_j, h_ne, eval_h, p_ne, eval_hprods)
+                            c, g, eval_r, j_ne, eval_jr, h_ne, eval_hr, p_ne, eval_shrprod)
   @ccall libgalahad_single_64.nls_solve_with_mat(data::Ptr{Ptr{Cvoid}},
                                                  userdata::Ptr{Cvoid}, status::Ptr{Int64},
                                                  n::Int64, m::Int64, x::Ptr{Float32},
                                                  c::Ptr{Float32}, g::Ptr{Float32},
-                                                 eval_c::Ptr{Cvoid}, j_ne::Int64,
-                                                 eval_j::Ptr{Cvoid}, h_ne::Int64,
-                                                 eval_h::Ptr{Cvoid}, p_ne::Int64,
-                                                 eval_hprods::Ptr{Cvoid})::Cvoid
+                                                 eval_r::Ptr{Cvoid}, j_ne::Int64,
+                                                 eval_jr::Ptr{Cvoid}, h_ne::Int64,
+                                                 eval_hr::Ptr{Cvoid}, p_ne::Int64,
+                                                 eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_with_mat(::Type{Float64}, ::Type{Int32}, data, userdata, status, n, m, x,
-                            c, g, eval_c, j_ne, eval_j, h_ne, eval_h, p_ne, eval_hprods)
+                            c, g, eval_r, j_ne, eval_jr, h_ne, eval_hr, p_ne, eval_shrprod)
   @ccall libgalahad_double.nls_solve_with_mat(data::Ptr{Ptr{Cvoid}}, userdata::Ptr{Cvoid},
                                               status::Ptr{Int32}, n::Int32, m::Int32,
                                               x::Ptr{Float64}, c::Ptr{Float64},
-                                              g::Ptr{Float64}, eval_c::Ptr{Cvoid},
-                                              j_ne::Int32, eval_j::Ptr{Cvoid}, h_ne::Int32,
-                                              eval_h::Ptr{Cvoid}, p_ne::Int32,
-                                              eval_hprods::Ptr{Cvoid})::Cvoid
+                                              g::Ptr{Float64}, eval_r::Ptr{Cvoid},
+                                              j_ne::Int32, eval_jr::Ptr{Cvoid}, h_ne::Int32,
+                                              eval_hr::Ptr{Cvoid}, p_ne::Int32,
+                                              eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_with_mat(::Type{Float64}, ::Type{Int64}, data, userdata, status, n, m, x,
-                            c, g, eval_c, j_ne, eval_j, h_ne, eval_h, p_ne, eval_hprods)
+                            c, g, eval_r, j_ne, eval_jr, h_ne, eval_hr, p_ne, eval_shrprod)
   @ccall libgalahad_double_64.nls_solve_with_mat(data::Ptr{Ptr{Cvoid}},
                                                  userdata::Ptr{Cvoid}, status::Ptr{Int64},
                                                  n::Int64, m::Int64, x::Ptr{Float64},
                                                  c::Ptr{Float64}, g::Ptr{Float64},
-                                                 eval_c::Ptr{Cvoid}, j_ne::Int64,
-                                                 eval_j::Ptr{Cvoid}, h_ne::Int64,
-                                                 eval_h::Ptr{Cvoid}, p_ne::Int64,
-                                                 eval_hprods::Ptr{Cvoid})::Cvoid
+                                                 eval_r::Ptr{Cvoid}, j_ne::Int64,
+                                                 eval_jr::Ptr{Cvoid}, h_ne::Int64,
+                                                 eval_hr::Ptr{Cvoid}, p_ne::Int64,
+                                                 eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_with_mat(::Type{Float128}, ::Type{Int32}, data, userdata, status, n, m,
-                            x, c, g, eval_c, j_ne, eval_j, h_ne, eval_h, p_ne, eval_hprods)
+                            x, c, g, eval_r, j_ne, eval_jr, h_ne, eval_hr, p_ne,
+                            eval_shrprod)
   @ccall libgalahad_quadruple.nls_solve_with_mat(data::Ptr{Ptr{Cvoid}},
                                                  userdata::Ptr{Cvoid}, status::Ptr{Int32},
                                                  n::Int32, m::Int32, x::Ptr{Float128},
                                                  c::Ptr{Float128}, g::Ptr{Float128},
-                                                 eval_c::Ptr{Cvoid}, j_ne::Int32,
-                                                 eval_j::Ptr{Cvoid}, h_ne::Int32,
-                                                 eval_h::Ptr{Cvoid}, p_ne::Int32,
-                                                 eval_hprods::Ptr{Cvoid})::Cvoid
+                                                 eval_r::Ptr{Cvoid}, j_ne::Int32,
+                                                 eval_jr::Ptr{Cvoid}, h_ne::Int32,
+                                                 eval_hr::Ptr{Cvoid}, p_ne::Int32,
+                                                 eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_with_mat(::Type{Float128}, ::Type{Int64}, data, userdata, status, n, m,
-                            x, c, g, eval_c, j_ne, eval_j, h_ne, eval_h, p_ne, eval_hprods)
+                            x, c, g, eval_r, j_ne, eval_jr, h_ne, eval_hr, p_ne,
+                            eval_shrprod)
   @ccall libgalahad_quadruple_64.nls_solve_with_mat(data::Ptr{Ptr{Cvoid}},
                                                     userdata::Ptr{Cvoid},
                                                     status::Ptr{Int64}, n::Int64, m::Int64,
                                                     x::Ptr{Float128}, c::Ptr{Float128},
-                                                    g::Ptr{Float128}, eval_c::Ptr{Cvoid},
-                                                    j_ne::Int64, eval_j::Ptr{Cvoid},
-                                                    h_ne::Int64, eval_h::Ptr{Cvoid},
+                                                    g::Ptr{Float128}, eval_r::Ptr{Cvoid},
+                                                    j_ne::Int64, eval_jr::Ptr{Cvoid},
+                                                    h_ne::Int64, eval_hr::Ptr{Cvoid},
                                                     p_ne::Int64,
-                                                    eval_hprods::Ptr{Cvoid})::Cvoid
+                                                    eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 export nls_solve_without_mat
 
 function nls_solve_without_mat(::Type{Float32}, ::Type{Int32}, data, userdata, status, n, m,
-                               x, c, g, eval_c, eval_jprod, eval_hprod, p_ne, eval_hprods)
+                               x, c, g, eval_r, eval_jrprod, eval_hrprod, p_ne,
+                               eval_shrprod)
   @ccall libgalahad_single.nls_solve_without_mat(data::Ptr{Ptr{Cvoid}},
                                                  userdata::Ptr{Cvoid}, status::Ptr{Int32},
                                                  n::Int32, m::Int32, x::Ptr{Float32},
                                                  c::Ptr{Float32}, g::Ptr{Float32},
-                                                 eval_c::Ptr{Cvoid}, eval_jprod::Ptr{Cvoid},
-                                                 eval_hprod::Ptr{Cvoid}, p_ne::Int32,
-                                                 eval_hprods::Ptr{Cvoid})::Cvoid
+                                                 eval_r::Ptr{Cvoid},
+                                                 eval_jrprod::Ptr{Cvoid},
+                                                 eval_hrprod::Ptr{Cvoid}, p_ne::Int32,
+                                                 eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_without_mat(::Type{Float32}, ::Type{Int64}, data, userdata, status, n, m,
-                               x, c, g, eval_c, eval_jprod, eval_hprod, p_ne, eval_hprods)
+                               x, c, g, eval_r, eval_jrprod, eval_hrprod, p_ne,
+                               eval_shrprod)
   @ccall libgalahad_single_64.nls_solve_without_mat(data::Ptr{Ptr{Cvoid}},
                                                     userdata::Ptr{Cvoid},
                                                     status::Ptr{Int64}, n::Int64, m::Int64,
                                                     x::Ptr{Float32}, c::Ptr{Float32},
-                                                    g::Ptr{Float32}, eval_c::Ptr{Cvoid},
-                                                    eval_jprod::Ptr{Cvoid},
-                                                    eval_hprod::Ptr{Cvoid}, p_ne::Int64,
-                                                    eval_hprods::Ptr{Cvoid})::Cvoid
+                                                    g::Ptr{Float32}, eval_r::Ptr{Cvoid},
+                                                    eval_jrprod::Ptr{Cvoid},
+                                                    eval_hrprod::Ptr{Cvoid}, p_ne::Int64,
+                                                    eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_without_mat(::Type{Float64}, ::Type{Int32}, data, userdata, status, n, m,
-                               x, c, g, eval_c, eval_jprod, eval_hprod, p_ne, eval_hprods)
+                               x, c, g, eval_r, eval_jrprod, eval_hrprod, p_ne,
+                               eval_shrprod)
   @ccall libgalahad_double.nls_solve_without_mat(data::Ptr{Ptr{Cvoid}},
                                                  userdata::Ptr{Cvoid}, status::Ptr{Int32},
                                                  n::Int32, m::Int32, x::Ptr{Float64},
                                                  c::Ptr{Float64}, g::Ptr{Float64},
-                                                 eval_c::Ptr{Cvoid}, eval_jprod::Ptr{Cvoid},
-                                                 eval_hprod::Ptr{Cvoid}, p_ne::Int32,
-                                                 eval_hprods::Ptr{Cvoid})::Cvoid
+                                                 eval_r::Ptr{Cvoid},
+                                                 eval_jrprod::Ptr{Cvoid},
+                                                 eval_hrprod::Ptr{Cvoid}, p_ne::Int32,
+                                                 eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_without_mat(::Type{Float64}, ::Type{Int64}, data, userdata, status, n, m,
-                               x, c, g, eval_c, eval_jprod, eval_hprod, p_ne, eval_hprods)
+                               x, c, g, eval_r, eval_jrprod, eval_hrprod, p_ne,
+                               eval_shrprod)
   @ccall libgalahad_double_64.nls_solve_without_mat(data::Ptr{Ptr{Cvoid}},
                                                     userdata::Ptr{Cvoid},
                                                     status::Ptr{Int64}, n::Int64, m::Int64,
                                                     x::Ptr{Float64}, c::Ptr{Float64},
-                                                    g::Ptr{Float64}, eval_c::Ptr{Cvoid},
-                                                    eval_jprod::Ptr{Cvoid},
-                                                    eval_hprod::Ptr{Cvoid}, p_ne::Int64,
-                                                    eval_hprods::Ptr{Cvoid})::Cvoid
+                                                    g::Ptr{Float64}, eval_r::Ptr{Cvoid},
+                                                    eval_jrprod::Ptr{Cvoid},
+                                                    eval_hrprod::Ptr{Cvoid}, p_ne::Int64,
+                                                    eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_without_mat(::Type{Float128}, ::Type{Int32}, data, userdata, status, n,
-                               m, x, c, g, eval_c, eval_jprod, eval_hprod, p_ne,
-                               eval_hprods)
+                               m, x, c, g, eval_r, eval_jrprod, eval_hrprod, p_ne,
+                               eval_shrprod)
   @ccall libgalahad_quadruple.nls_solve_without_mat(data::Ptr{Ptr{Cvoid}},
                                                     userdata::Ptr{Cvoid},
                                                     status::Ptr{Int32}, n::Int32, m::Int32,
                                                     x::Ptr{Float128}, c::Ptr{Float128},
-                                                    g::Ptr{Float128}, eval_c::Ptr{Cvoid},
-                                                    eval_jprod::Ptr{Cvoid},
-                                                    eval_hprod::Ptr{Cvoid}, p_ne::Int32,
-                                                    eval_hprods::Ptr{Cvoid})::Cvoid
+                                                    g::Ptr{Float128}, eval_r::Ptr{Cvoid},
+                                                    eval_jrprod::Ptr{Cvoid},
+                                                    eval_hrprod::Ptr{Cvoid}, p_ne::Int32,
+                                                    eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 function nls_solve_without_mat(::Type{Float128}, ::Type{Int64}, data, userdata, status, n,
-                               m, x, c, g, eval_c, eval_jprod, eval_hprod, p_ne,
-                               eval_hprods)
+                               m, x, c, g, eval_r, eval_jrprod, eval_hrprod, p_ne,
+                               eval_shrprod)
   @ccall libgalahad_quadruple_64.nls_solve_without_mat(data::Ptr{Ptr{Cvoid}},
                                                        userdata::Ptr{Cvoid},
                                                        status::Ptr{Int64}, n::Int64,
                                                        m::Int64, x::Ptr{Float128},
                                                        c::Ptr{Float128}, g::Ptr{Float128},
-                                                       eval_c::Ptr{Cvoid},
-                                                       eval_jprod::Ptr{Cvoid},
-                                                       eval_hprod::Ptr{Cvoid}, p_ne::Int64,
-                                                       eval_hprods::Ptr{Cvoid})::Cvoid
+                                                       eval_r::Ptr{Cvoid},
+                                                       eval_jrprod::Ptr{Cvoid},
+                                                       eval_hrprod::Ptr{Cvoid}, p_ne::Int64,
+                                                       eval_shrprod::Ptr{Cvoid})::Cvoid
 end
 
 export nls_solve_reverse_with_mat

--- a/include/galahad_arc.h
+++ b/include/galahad_arc.h
@@ -227,6 +227,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_rqs.h"
 #include "galahad_glrt.h"
@@ -792,16 +795,10 @@ void arc_solve_with_mat( void **data,
                          rpc_ x[],
                          rpc_ g[],
                          ipc_ ne,
-                         ipc_ (*eval_f)(
-                           ipc_, const rpc_[], rpc_*, const void * ),
-                         ipc_ (*eval_g)(
-                           ipc_, const rpc_[], rpc_[], const void * ),
-                         ipc_ (*eval_h)(
-                           ipc_, ipc_, const rpc_[], rpc_[],
-                           const void * ),
-                         ipc_ (*eval_prec)(
-                           ipc_, const rpc_[], rpc_[], const rpc_[],
-                           const void * ) );
+                         galahad_f *eval_f,
+                         galahad_g *eval_g,
+                         galahad_h *eval_h,
+                         galahad_prec *eval_prec );
 
 /*!<
  Find a local minimizer of a given function using a regularization method.
@@ -921,16 +918,10 @@ void arc_solve_without_mat( void **data,
                             ipc_ n,
                             rpc_ x[],
                             rpc_ g[],
-                            ipc_ (*eval_f)(
-                              ipc_, const rpc_[], rpc_*, const void * ),
-                            ipc_ (*eval_g)(
-                              ipc_, const rpc_[], rpc_[], const void * ),
-                            ipc_ (*eval_hprod)(
-                              ipc_, const rpc_[], rpc_[],
-                              const rpc_[], bool, const void * ),
-                            ipc_ (*eval_prec)(
-                              ipc_, const rpc_[], rpc_[],
-                               const rpc_[], const void * ) );
+                            galahad_f *eval_f,
+                            galahad_g *eval_g,
+                            galahad_hprod *eval_hprod,
+                            galahad_prec *eval_prec );
 
 /*!<
  Find a local minimizer of a given function using a regularization method.

--- a/include/galahad_bgo.h
+++ b/include/galahad_bgo.h
@@ -252,6 +252,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_trb.h"
 #include "galahad_ugo.h"
@@ -598,19 +601,11 @@ void bgo_solve_with_mat( void **data,
                          rpc_ x[],
                          rpc_ g[],
                          ipc_ ne,
-                         ipc_ (*eval_f)(
-                           ipc_, const rpc_[], rpc_*, const void * ),
-                         ipc_ (*eval_g)(
-                           ipc_, const rpc_[], rpc_[], const void * ),
-                         ipc_ (*eval_h)(
-                           ipc_, ipc_, const rpc_[], rpc_[],
-                           const void * ),
-                         ipc_ (*eval_hprod)(
-                           ipc_, const rpc_[], rpc_[], const rpc_[],
-                           bool, const void * ),
-                         ipc_ (*eval_prec)(
-                           ipc_, const rpc_[], rpc_[], const rpc_[],
-                           const void * ) );
+                         galahad_f *eval_f,
+                         galahad_g *eval_g,
+                         galahad_h *eval_h,
+                         galahad_hprod *eval_hprod,
+                         galahad_prec *eval_prec);
 
 /*!<
  Find an approximation to the global minimizer of a given function subject to
@@ -731,19 +726,11 @@ void bgo_solve_without_mat( void **data,
                             ipc_ n,
                             rpc_ x[],
                             rpc_ g[],
-                            ipc_ (*eval_f)(
-                              ipc_, const rpc_[], rpc_*, const void * ),
-                            ipc_ (*eval_g)(
-                              ipc_, const rpc_[], rpc_[], const void * ),
-                            ipc_ (*eval_hprod)(
-                              ipc_, const rpc_[], rpc_[],
-                              const rpc_[], bool, const void * ),
-                            ipc_ (*eval_shprod)(ipc_, const rpc_[], ipc_,
-                              const ipc_[], const rpc_[], ipc_*, ipc_[],
-                              rpc_[], bool, const void * ),
-                            ipc_ (*eval_prec)(
-                              ipc_, const rpc_[], rpc_[],
-                              const rpc_[], const void * ) );
+                            galahad_f *eval_f,
+                            galahad_g *eval_g,
+                            galahad_hprod *eval_hprod,
+                            galahad_shprod *eval_shprod,
+                            galahad_prec *eval_prec );
 
 /*!<
  Find an approximation to the global minimizer of a given function subject to

--- a/include/galahad_blls.h
+++ b/include/galahad_blls.h
@@ -245,6 +245,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_sbls.h"
 #include "galahad_convert.h"
@@ -714,9 +717,7 @@ void blls_solve_given_a( void **data,
                          rpc_ g[],
                          ipc_ x_stat[],
                          const rpc_ w[],
-                         ipc_ (*eval_prec)(
-                              ipc_, const rpc_[],
-                              rpc_[], const void * ) );
+                         galahad_constant_prec *eval_prec );
 
 /*!<
  Solve the bound-constrained linear least-squares problem when the

--- a/include/galahad_callbacks.h
+++ b/include/galahad_callbacks.h
@@ -1,0 +1,47 @@
+// include guard
+#ifndef GALAHAD_CALLBACKS_H
+#define GALAHAD_CALLBACKS_H
+
+// precision
+#include "galahad_precision.h"
+
+#ifdef __cplusplus
+extern "C" {
+#else
+#include <stdbool.h>
+#include <stdint.h>
+#endif
+
+// ARC, BGO, DGO, TRB, TRU
+typedef ipc_ galahad_f( ipc_ n, const rpc_ x[], rpc_ *f, const void *userdata );
+typedef ipc_ galahad_g( ipc_ n, const rpc_ x[], rpc_ g[], const void *userdata );
+typedef ipc_ galahad_h( ipc_ n, ipc_ ne, const rpc_ x[], rpc_ h[], const void *userdata );
+typedef ipc_ galahad_prec( ipc_ n, const rpc_ x[], rpc_ u[], const rpc_ v[], const void *userdata );
+typedef ipc_ galahad_hprod( ipc_ n, const rpc_ x[], rpc_ u[], const rpc_ v[], bool got_h, const void *userdata );
+typedef ipc_ galahad_shprod( ipc_ n, const rpc_ x[], ipc_ nnz_v, const ipc_ index_nz_v[], const rpc_ v[], ipc_ *nnz_u, ipc_ index_nz_u[], rpc_ u[], bool got_h, const void *userdata );
+
+// BLLS, SLLS
+typedef ipc_ galahad_constant_prec( ipc_ n, const rpc_ v[], rpc_ p[], const void *userdata );
+
+// NLS
+typedef ipc_ galahad_r( ipc_ n, ipc_ m, const rpc_ x[], rpc_ r[], const void *userdata );
+typedef ipc_ galahad_jr( ipc_ n, ipc_ m, ipc_ jne, const rpc_ x[], rpc_ jr[], const void *userdata );
+typedef ipc_ galahad_hr( ipc_ n, ipc_ m, ipc_ hne, const rpc_ x[], const rpc_ y[], rpc_ hr[], const void *userdata );
+typedef ipc_ galahad_jrprod( ipc_ n, ipc_ m, const rpc_ x[], const bool transpose, rpc_ u[], const rpc_ v[], bool got_j, const void *userdata );
+typedef ipc_ galahad_hrprod( ipc_ n, ipc_ m, const rpc_ x[], const rpc_ y[], rpc_ u[], const rpc_ v[], bool got_h, const void *userdata );
+typedef ipc_ galahad_shrprod( ipc_ n, ipc_ m, ipc_ pne, const rpc_ x[], const rpc_ v[], rpc_ pval[], bool got_h, const void *userdata );
+
+// EXPO
+typedef ipc_ galahad_fc( ipc_ n, ipc_ m, const rpc_ x[], rpc_ *f, rpc_ c[], const void *userdata );
+typedef ipc_ galahad_gj( ipc_ n, ipc_ m, ipc_ jne, const rpc_ x[], rpc_ g[], rpc_ j[], const void *userdata );
+typedef ipc_ galahad_hl( ipc_ n, ipc_ m, ipc_ hne, const rpc_ x[], const rpc_ y[], rpc_ h[], const void *userdata );
+
+// UGO
+typedef ipc_ galahad_fgh( rpc_ x, rpc_ *f, rpc_ *g, rpc_*h, const void *userdata );
+
+#ifdef __cplusplus
+}
+#endif
+
+// end include guard
+#endif

--- a/include/galahad_dgo.h
+++ b/include/galahad_dgo.h
@@ -215,6 +215,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_trb.h"
 #include "galahad_ugo.h"
@@ -617,19 +620,11 @@ void dgo_solve_with_mat( void **data,
                          rpc_ x[],
                          rpc_ g[],
                          ipc_ ne,
-                         ipc_ (*eval_f)(
-                           ipc_, const rpc_[], rpc_*, const void * ),
-                         ipc_ (*eval_g)(
-                           ipc_, const rpc_[], rpc_[], const void * ),
-                         ipc_ (*eval_h)(
-                           ipc_, ipc_, const rpc_[], rpc_[],
-                           const void * ),
-                         ipc_ (*eval_hprod)(
-                           ipc_, const rpc_[], rpc_[], const rpc_[],
-                           bool, const void * ),
-                         ipc_ (*eval_prec)(
-                           ipc_, const rpc_[], rpc_[], const rpc_[],
-                           const void * ) );
+                         galahad_f *eval_f,
+                         galahad_g *eval_g,
+                         galahad_h *eval_h,
+                         galahad_hprod *eval_hprod,
+                         galahad_prec *eval_prec );
 
 /*!<
  Find an approximation to the global minimizer of a given function subject to
@@ -755,20 +750,11 @@ void dgo_solve_without_mat( void **data,
                             ipc_ n,
                             rpc_ x[],
                             rpc_ g[],
-                            ipc_ (*eval_f)(
-                              ipc_, const rpc_[], rpc_*, const void * ),
-                            ipc_ (*eval_g)(
-                              ipc_, const rpc_[], rpc_[], 
-                              const void * ),
-                            ipc_ (*eval_hprod)(
-                              ipc_, const rpc_[], rpc_[],
-                              const rpc_[], bool, const void * ),
-                            ipc_ (*eval_shprod)(ipc_, const rpc_[], ipc_,
-                              const ipc_[], const rpc_[], ipc_*, ipc_[],
-                              rpc_[], bool, const void * ),
-                            ipc_ (*eval_prec)(
-                              ipc_, const rpc_[], rpc_[],
-                              const rpc_[], const void * ) );
+                            galahad_f *eval_f,
+                            galahad_g *eval_g,
+                            galahad_hprod *eval_hprod,
+                            galahad_shprod *eval_shprod,
+                            galahad_prec *eval_prec );
 
 /*!<
  Find an approximation to the global minimizer of a given function subject to

--- a/include/galahad_expo.h
+++ b/include/galahad_expo.h
@@ -414,6 +414,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_bsc.h"
 #include "galahad_tru.h"
@@ -880,15 +883,9 @@ void expo_solve_hessian_direct( void **data,
                                 rpc_ z[],
                                 rpc_ c[],
                                 rpc_ gl[],
-                                ipc_ (*eval_fc)(
-                                  ipc_, ipc_, const rpc_[],
-                                  rpc_ *, rpc_[], const void * ),
-                                ipc_ (*eval_gj)(
-                                  ipc_, ipc_, ipc_, const rpc_[],
-                                  rpc_[], rpc_[], const void * ),
-                                ipc_ (*eval_hl)(
-                                  ipc_, ipc_, ipc_, const rpc_[], const rpc_[],
-                                  rpc_[], const void * ) );
+                                galahad_fc *eval_fc,
+                                galahad_gj *eval_gj,
+                                galahad_hl *eval_hl );
 
 /*!<
  Find a local minimizer of the constrained optimization problem using the

--- a/include/galahad_slls.h
+++ b/include/galahad_slls.h
@@ -244,6 +244,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_sbls.h"
 #include "galahad_convert.h"
@@ -674,9 +677,7 @@ void slls_solve_given_a( void **data,
                          rpc_ r[],
                          rpc_ g[],
                          ipc_ x_stat[],
-                         ipc_ (*eval_prec)(
-                              ipc_, const rpc_[],
-                              rpc_[], const void * ) );
+                         galahad_constant_prec *eval_prec );
 
 /*!<
  Solve the bound-constrained linear least-squares problem when the

--- a/include/galahad_trb.h
+++ b/include/galahad_trb.h
@@ -232,6 +232,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_trs.h"
 #include "galahad_gltr.h"
@@ -809,16 +812,10 @@ void trb_solve_with_mat( void **data,
                          rpc_ x[],
                          rpc_ g[],
                          ipc_ ne,
-                         ipc_ (*eval_f)(
-                           ipc_, const rpc_[], rpc_*, const void * ),
-                         ipc_ (*eval_g)(
-                           ipc_, const rpc_[], rpc_[], const void * ),
-                         ipc_ (*eval_h)(
-                           ipc_, ipc_, const rpc_[], rpc_[],
-                           const void * ),
-                         ipc_ (*eval_prec)(
-                           ipc_, const rpc_[], rpc_[], const rpc_[],
-                           const void * ) );
+                         galahad_f *eval_f,
+                         galahad_g *eval_g,
+                         galahad_h *eval_h,
+                         galahad_prec *eval_prec );
 
 /*!<
  Find a local minimizer of a given function subject to simple bounds on
@@ -951,21 +948,11 @@ void trb_solve_without_mat( void **data,
                             const rpc_ x_u[],
                             rpc_ x[],
                             rpc_ g[],
-                            ipc_ (*eval_f)(
-                              ipc_, const rpc_[], rpc_*, const void * ),
-                            ipc_ (*eval_g)(
-                              ipc_, const rpc_[], rpc_[], 
-                              const void * ),
-                            ipc_ (*eval_hprod)(
-                              ipc_, const rpc_[], rpc_[],
-                              const rpc_[], bool, const void * ),
-                            ipc_ (*eval_shprod)(
-                              ipc_, const rpc_[], ipc_, const ipc_[],
-                              const rpc_[], ipc_*, ipc_[],
-                              rpc_[], bool, const void * ),
-                            ipc_ (*eval_prec)(
-                              ipc_, const rpc_[], rpc_[],
-                               const rpc_[], const void * ) );
+                            galahad_f *eval_f,
+                            galahad_g *eval_g,
+                            galahad_hprod *eval_hprod,
+                            galahad_shprod *eval_shprod,
+                            galahad_prec *eval_prec );
 
 /*!<
  Find a local minimizer of a given function subject to simple bounds on

--- a/include/galahad_tru.h
+++ b/include/galahad_tru.h
@@ -217,6 +217,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 // required packages
 #include "galahad_trs.h"
 #include "galahad_gltr.h"
@@ -779,16 +782,10 @@ void tru_solve_with_mat( void **data,
                          rpc_ x[],
                          rpc_ g[],
                          ipc_ ne,
-                         ipc_ (*eval_f)(
-                           ipc_, const rpc_[], rpc_*, const void * ),
-                         ipc_ (*eval_g)(
-                           ipc_, const rpc_[], rpc_[], const void * ),
-                         ipc_ (*eval_h)(
-                           ipc_, ipc_, const rpc_[], rpc_[],
-                           const void * ),
-                         ipc_ (*eval_prec)(
-                           ipc_, const rpc_[], rpc_[], const rpc_[],
-                           const void * ) );
+                         galahad_f *eval_f,
+                         galahad_g *eval_g,
+                         galahad_h *eval_h,
+                         galahad_prec *eval_prec );
 
 /*!<
  Find a local minimizer of a given function using a trust-region method.
@@ -908,16 +905,10 @@ void tru_solve_without_mat( void **data,
                             ipc_ n,
                             rpc_ x[],
                             rpc_ g[],
-                            ipc_ (*eval_f)(
-                              ipc_, const rpc_[], rpc_*, const void * ),
-                            ipc_ (*eval_g)(
-                              ipc_, const rpc_[], rpc_[], const void * ),
-                            ipc_ (*eval_hprod)(
-                              ipc_, const rpc_[], rpc_[],
-                              const rpc_[], bool, const void * ),
-                            ipc_ (*eval_prec)(
-                              ipc_, const rpc_[], rpc_[],
-                               const rpc_[], const void * ) );
+                            galahad_f *eval_f,
+                            galahad_g *eval_g,
+                            galahad_hprod *eval_hprod,
+                            galahad_prec *eval_prec );
 
 /*!<
  Find a local minimizer of a given function using a trust-region method.

--- a/include/galahad_ugo.h
+++ b/include/galahad_ugo.h
@@ -113,6 +113,9 @@ extern "C" {
 #include "galahad_precision.h"
 #include "galahad_cfunctions.h"
 
+// callbacks
+#include "galahad_callbacks.h"
+
 /*
  * control derived type as a C struct
  */
@@ -437,9 +440,7 @@ void ugo_solve_direct( void **data,
                        rpc_ *f,
                        rpc_ *g,
                        rpc_ *h,
-                       ipc_ (*eval_fgh)(
-                          rpc_, rpc_*, rpc_*, rpc_*,
-                          const void * ) );
+                       galahad_fgh *eval_fgh );
 
 /*!<
  Find an approximation to the global minimizer of a given univariate

--- a/include/meson.build
+++ b/include/meson.build
@@ -4,13 +4,15 @@ galahad_headers += files('galahad_modules.h',
                          'galahad_modules_quadruple.h')
 
 if build_ciface
-  galahad_headers += files('galahad_arc.h',
+  galahad_headers += files('galahad.h',
+                           'galahad_arc.h',
                            'galahad_bgo.h',
                            'galahad_blls.h',
                            'galahad_bllsb.h',
                            'galahad_bqpb.h',
                            'galahad_bqp.h',
                            'galahad_bsc.h',
+                           'galahad_callbacks.h',
                            'galahad_ccqp.h',
                            'galahad_cfunctions.h',
                            'galahad_clls.h',
@@ -27,7 +29,6 @@ if build_ciface
                            'galahad_glrt.h',
                            'galahad_gls.h',
                            'galahad_gltr.h',
-                           'galahad.h',
                            'galahad_hash.h',
                            'galahad_ir.h',
                            'galahad_l2rt.h',
@@ -67,7 +68,6 @@ if build_ciface
 
   galahad_headers += files('ssids_rip.hxx', 'spral_ssids.h')
 endif
-# 'galahad_icfs.h'
 
 if build_pythoniface
   galahad_headers += files('galahad_python.h')


### PR DESCRIPTION
@nimgould I worked on a  `galahad_callbacks.h` to easily reuse the signatures of GALAHAD callbacks in the various packages (and ensure a uniform API).
I also find that it is easier to understand the signature of the callbacks in the headers that support direct communication.

The users don't need to write the prototypes in their code too, they can do something like this:
```shell
galahad_f fun;
galahad_g grad;
galahad_h hess;
```
instead of 
```shell
// Function prototypes
ipc_ fun(ipc_ n, const rpc_ x[], rpc_ *f, const void *);
ipc_ grad(ipc_ n, const rpc_ x[], rpc_ g[], const void *);
ipc_ hess(ipc_ n, ipc_ ne, const rpc_ x[], rpc_ hval[], const void *);
```
Which allow to ensure that their callbacks respect what the C interface of GALAHAD routines require.
Otherwise they will have a compilation error / warning.

I needed these new  "typedef" to have a clean signature in the multiprecision `galahad_c.h`.