### PR TITLE
[CI] Ensure python never builds quadruple precision shared library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ['meson-python', 'numpy']
 allow-windows-internal-shared-libs = true
 
 [tool.meson-python.args]
-setup = ['-Dpythoniface=true', '-Dpython.install_env=auto', '-Dsingle=false', '-Dtests=false']
+setup = ['-Dpythoniface=true', '-Dpython.install_env=auto', '-Dsingle=false', '-Dquadruple=false', '-Dtests=false']
 install = ['--tags=runtime,python-runtime']
 
 [project]


### PR DESCRIPTION
PR to ensure that Python only ever builds the double precision library.